### PR TITLE
feat: replace default animations

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -426,3 +426,5 @@ export const BROWSER_ACTIONS = {
   share: 'share',
   favourite: 'favourite',
 } as const;
+
+export const PAGE_TRANSITION_DURATION = 150;

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -22,7 +22,7 @@
         class="app-inner"
         :class="{ 'styled-scrollbar': showScrollbar }"
       >
-        <Header v-if="showHeader" />
+        <Header :show="showHeader" />
 
         <!-- We are disabling animations on FF because of a bug that causes flickering
           see: https://github.com/ionic-team/ionic-framework/issues/26620 -->
@@ -292,7 +292,6 @@ export default defineComponent({
     --screen-padding-x: 16px;
     --screen-border-radius: 0;
     --screen-bg-color: #{variables.$color-bg-app};
-    --header-height: 0;
     --gap: 12px;
 
     @extend %face-sans-16-regular;

--- a/src/popup/animations/fade.ts
+++ b/src/popup/animations/fade.ts
@@ -1,0 +1,20 @@
+import { createAnimation } from '@ionic/vue';
+
+const ANIMATION_DURATION = 100;
+
+export const fadeAnimation = (_: Element, opts: { enteringEl: Element, leavingEl: Element }) => {
+  const enteringAnimation = createAnimation()
+    .addElement(opts.enteringEl)
+    .fromTo('opacity', 0, 1)
+    .duration(ANIMATION_DURATION);
+
+  const leavingAnimation = createAnimation()
+    .addElement(opts.leavingEl)
+    .fromTo('opacity', 1, 0);
+
+  const animation = createAnimation()
+    .addAnimation(enteringAnimation)
+    .addAnimation(leavingAnimation);
+
+  return animation;
+};

--- a/src/popup/animations/index.ts
+++ b/src/popup/animations/index.ts
@@ -1,0 +1,3 @@
+export * from './popIn';
+export * from './popOut';
+export * from './fade';

--- a/src/popup/animations/popIn.ts
+++ b/src/popup/animations/popIn.ts
@@ -1,0 +1,21 @@
+import { PAGE_TRANSITION_DURATION } from '@/constants';
+import { createAnimation } from '@ionic/vue';
+
+export const popInAnimation = (_: Element, opts: { enteringEl: Element, leavingEl: Element }) => {
+  const enteringAnimation = createAnimation()
+    .addElement(opts.enteringEl)
+    .fromTo('opacity', 0, 1)
+    .fromTo('transform', 'translateY(70%)', 'translateY(0px)')
+    .duration(PAGE_TRANSITION_DURATION);
+
+  const leavingAnimation = createAnimation()
+    .addElement(opts.leavingEl)
+    .fromTo('opacity', 1, 0)
+    .duration(PAGE_TRANSITION_DURATION);
+
+  const animation = createAnimation()
+    .addAnimation(enteringAnimation)
+    .addAnimation(leavingAnimation);
+
+  return animation;
+};

--- a/src/popup/animations/popOut.ts
+++ b/src/popup/animations/popOut.ts
@@ -1,0 +1,21 @@
+import { PAGE_TRANSITION_DURATION } from '@/constants';
+import { createAnimation } from '@ionic/vue';
+
+export const popOutAnimation = (_: Element, opts: { enteringEl: Element, leavingEl: Element }) => {
+  const enteringAnimation = createAnimation()
+    .addElement(opts.enteringEl)
+    .fromTo('opacity', 0, 1)
+    .duration(PAGE_TRANSITION_DURATION);
+
+  const leavingAnimation = createAnimation()
+    .addElement(opts.leavingEl)
+    .fromTo('opacity', 1, 0)
+    .fromTo('transform', 'translateY(0)', 'translateY(70%)')
+    .duration(PAGE_TRANSITION_DURATION);
+
+  const animation = createAnimation()
+    .addAnimation(enteringAnimation)
+    .addAnimation(leavingAnimation);
+
+  return animation;
+};

--- a/src/popup/components/AccountDetailsBase.vue
+++ b/src/popup/components/AccountDetailsBase.vue
@@ -46,7 +46,7 @@
         <slot name="navigation" />
 
         <TransactionAndTokenFilter
-          :key="routeName"
+          :key="routeName!"
           :show-filters="isScrollEnabled"
         />
       </div>
@@ -57,7 +57,10 @@
       >
         <!-- We are disabling animations on FF because of a bug that causes flickering
           see: https://github.com/ionic-team/ionic-framework/issues/26620 -->
-        <IonRouterOutlet :animated="!IS_FIREFOX" />
+        <IonRouterOutlet
+          :animated="!IS_FIREFOX"
+          :animation="fadeAnimation"
+        />
       </div>
     </div>
   </div>
@@ -88,8 +91,9 @@ import OpenTransferReceiveModalButton from '@/popup/components/OpenTransferRecei
 import OpenTransferSendModalButton from '@/popup/components/OpenTransferSendModalButton.vue';
 import BalanceInfo from '@/popup/components/BalanceInfo.vue';
 import AccountInfo from '@/popup/components/AccountInfo.vue';
-import BtnClose from './buttons/BtnClose.vue';
-import TransactionAndTokenFilter from './TransactionAndTokenFilter.vue';
+import BtnClose from '@/popup/components/buttons/BtnClose.vue';
+import TransactionAndTokenFilter from '@/popup/components/TransactionAndTokenFilter.vue';
+import { popOutAnimation, fadeAnimation } from '@/popup/animations';
 
 export default defineComponent({
   name: 'AccountDetailsBase',
@@ -129,7 +133,7 @@ export default defineComponent({
     }
 
     function close() {
-      ionRouter.navigate({ name: homeRouteName.value }, 'back', 'push');
+      ionRouter.navigate({ name: homeRouteName.value }, 'back', 'push', popOutAnimation);
     }
 
     /**
@@ -179,6 +183,7 @@ export default defineComponent({
       activeAccount,
       routerHeight,
       isScrollEnabled,
+      fadeAnimation,
       IS_FIREFOX,
     };
   },

--- a/src/popup/components/DefaultPagesRouter.vue
+++ b/src/popup/components/DefaultPagesRouter.vue
@@ -2,7 +2,11 @@
   <IonPage>
     <!-- We are disabling animations on FF because of a bug that causes flickering
       see: https://github.com/ionic-team/ionic-framework/issues/26620 -->
-    <IonRouterOutlet :animated="!RUNNING_IN_TESTS && !IS_FIREFOX" />
+
+    <IonRouterOutlet
+      :animated="!RUNNING_IN_TESTS && !IS_FIREFOX"
+      :animation="popInAnimation"
+    />
   </IonPage>
 </template>
 
@@ -12,6 +16,7 @@ import { IonRouterOutlet, IonPage } from '@ionic/vue';
 import { useRoute } from 'vue-router';
 import { useUi } from '@/composables';
 import { RUNNING_IN_TESTS, IS_FIREFOX } from '@/constants';
+import { popInAnimation } from '@/popup/animations';
 import { ROUTE_ACCOUNT, ROUTE_MULTISIG_ACCOUNT } from '../router/routeNames';
 
 export default defineComponent({
@@ -45,6 +50,7 @@ export default defineComponent({
     return {
       RUNNING_IN_TESTS,
       IS_FIREFOX,
+      popInAnimation,
     };
   },
 });

--- a/src/popup/components/Header.vue
+++ b/src/popup/components/Header.vue
@@ -1,5 +1,8 @@
 <template>
-  <IonHeader class="header ion-no-border">
+  <IonHeader
+    class="header ion-no-border"
+    :class="{ 'hidden': !showHeader }"
+  >
     <IonToolbar class="toolbar">
       <div
         class="wrapper"
@@ -73,10 +76,15 @@ import {
   useBackButton,
   useIonRouter,
 } from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
+import {
+  computed,
+  defineComponent,
+  ref,
+  watch,
+} from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { IS_MOBILE_APP, UNFINISHED_FEATURES } from '@/constants';
+import { IS_MOBILE_APP, PAGE_TRANSITION_DURATION, UNFINISHED_FEATURES } from '@/constants';
 import type { WalletRouteMeta } from '@/types';
 import {
   ROUTE_ACCOUNT,
@@ -110,13 +118,18 @@ export default defineComponent({
     IonHeader,
     IonToolbar,
   },
-  setup() {
+  props: {
+    show: Boolean,
+  },
+  setup(props) {
     const route = useRoute();
     const ionRouter = useIonRouter();
     const { t } = useI18n();
 
     const { homeRouteName } = useUi();
     const { isLoggedIn } = useAccounts();
+
+    const showHeader = ref(false);
 
     const pageTitles: Record<string, () => string> = {
       settings: () => t('pages.titles.settings'),
@@ -194,6 +207,20 @@ export default defineComponent({
 
     useBackButton(1, back);
 
+    watch(
+      () => props.show,
+      async (value) => {
+        if (value) {
+          showHeader.value = true;
+        } else {
+          setTimeout(() => {
+            showHeader.value = false;
+          }, PAGE_TRANSITION_DURATION);
+        }
+      },
+      { immediate: true },
+    );
+
     return {
       UNFINISHED_FEATURES,
       homeRouteName,
@@ -206,6 +233,7 @@ export default defineComponent({
       showHeaderNavigation,
       isLogoDisabled,
       titleTruncated,
+      showHeader,
       back,
       close,
     };
@@ -221,6 +249,13 @@ export default defineComponent({
 .header {
   z-index: variables.$z-index-header;
   height: var(--header-height);
+  opacity: 1;
+  transition: opacity 0.15s ease-in-out;
+
+  &.hidden {
+    z-index: -1;
+    opacity: 0;
+  }
 
   .toolbar {
     --opacity: 0;

--- a/src/popup/pages/FungibleTokens/TokenContainer.vue
+++ b/src/popup/pages/FungibleTokens/TokenContainer.vue
@@ -64,7 +64,7 @@
               />
             </Tabs>
             <TransactionAndTokenFilter
-              :key="routeName"
+              :key="routeName!"
               :show-filters="showFilterBar"
             />
           </div>
@@ -73,6 +73,7 @@
           see: https://github.com/ionic-team/ionic-framework/issues/26620 -->
         <IonRouterOutlet
           :animated="!IS_FIREFOX"
+          :animation="fadeAnimation"
           class="token-router"
           :style="{ height: routerHeight || '350px' }"
         />
@@ -128,6 +129,7 @@ import { useState, useGetter } from '@/composables/vuex';
 import { AE_CONTRACT_ID, AE_DEX_URL } from '@/protocols/aeternity/config';
 import { buildAeFaucetUrl, buildSimplexLink, isContract } from '@/protocols/aeternity/helpers';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
+import { fadeAnimation } from '@/popup/animations';
 
 import BtnBox from '../../components/buttons/BtnBox.vue';
 import TokenAmount from '../../components/TokenAmount.vue';
@@ -306,6 +308,7 @@ export default defineComponent({
       route,
       routerHeight,
       IS_FIREFOX,
+      fadeAnimation,
     };
   },
 });

--- a/src/popup/pages/Names/Auction.vue
+++ b/src/popup/pages/Names/Auction.vue
@@ -17,6 +17,7 @@
 
       <IonRouterOutlet
         v-if="!isLoaderVisible"
+        :animation="fadeAnimation"
         class="auction-router"
         :name="name"
       />
@@ -42,6 +43,7 @@ import { aettosToAe } from '@/protocols/aeternity/helpers';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 import { ROUTE_AUCTION_BID, ROUTE_AUCTION_HISTORY } from '@/popup/router/routeNames';
 import { useMiddleware, useUi } from '@/composables';
+import { fadeAnimation } from '@/popup/animations';
 
 import Tabs from '../../components/tabs/Tabs.vue';
 import Tab from '../../components/tabs/Tab.vue';
@@ -113,6 +115,7 @@ export default defineComponent({
       ROUTE_AUCTION_HISTORY,
       isLoaderVisible,
       routeParams,
+      fadeAnimation,
     };
   },
 });

--- a/src/protocols/aeternity/views/AccountDetailsNames.vue
+++ b/src/protocols/aeternity/views/AccountDetailsNames.vue
@@ -6,6 +6,7 @@
       <IonRouterOutlet
         v-if="isOnline"
         :animated="!IS_FIREFOX"
+        :animation="fadeAnimation"
       />
       <MessageOffline
         v-else
@@ -20,6 +21,7 @@
 import { IonRouterOutlet, IonPage } from '@ionic/vue';
 import { defineComponent } from 'vue';
 import { IS_FIREFOX } from '@/constants';
+import { fadeAnimation } from '@/popup/animations';
 import { useConnection } from '@/composables';
 import MessageOffline from '@/popup/components/MessageOffline.vue';
 
@@ -35,6 +37,7 @@ export default defineComponent({
     return {
       isOnline,
       IS_FIREFOX,
+      fadeAnimation,
     };
   },
 });


### PR DESCRIPTION
closes #2420 
Replace default animations when opening/closing `account-details` and when switching tabs
