### PR TITLE
refactor: protocols const to an enum

### DIFF
--- a/src/composables/accounts.ts
+++ b/src/composables/accounts.ts
@@ -11,8 +11,8 @@ import type {
 } from '@/types';
 import {
   ACCOUNT_HD_WALLET,
-  PROTOCOL_AETERNITY,
   PROTOCOLS,
+  PROTOCOL_LIST,
   STORAGE_KEYS,
 } from '@/constants';
 import {
@@ -76,7 +76,7 @@ const accounts = computed((): IAccount[] => {
     return [];
   }
 
-  const idxList = PROTOCOLS.reduce(
+  const idxList = PROTOCOL_LIST.reduce(
     (list, protocol) => ({ ...list, [protocol]: 0 }),
     {} as Record<Protocol, number>,
   );
@@ -114,7 +114,7 @@ const accountsGroupedByProtocol = computed(
 );
 
 const aeAccounts = computed(
-  (): IAccount[] => accountsGroupedByProtocol.value[PROTOCOL_AETERNITY] || [],
+  (): IAccount[] => accountsGroupedByProtocol.value[PROTOCOLS.aeternity] || [],
 );
 
 const accountsAddressList = computed(
@@ -232,14 +232,14 @@ export function useAccounts() {
    */
   async function discoverAccounts() {
     const lastUsedAccountIndexRegistry: number[] = await Promise.all(
-      PROTOCOLS.map(
+      PROTOCOL_LIST.map(
         (protocol) => ProtocolAdapterFactory
           .getAdapter(protocol)
           .discoverLastUsedAccountIndex(mnemonicSeed.value),
       ),
     );
 
-    PROTOCOLS.forEach((protocol, index) => {
+    PROTOCOL_LIST.forEach((protocol, index) => {
       for (let i = 0; i <= lastUsedAccountIndexRegistry[index]; i += 1) {
         addRawAccount({ isRestored: true, protocol });
       }

--- a/src/composables/aeSdk.ts
+++ b/src/composables/aeSdk.ts
@@ -25,7 +25,7 @@ import {
   IS_EXTENSION,
   IS_EXTENSION_BACKGROUND,
   RUNNING_IN_TESTS,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   AE_NETWORK_MAINNET_ID,
@@ -125,7 +125,7 @@ export function useAeSdk() {
           const aepp = aeppInfo[aeppId];
           const host = IS_EXTENSION_BACKGROUND ? aepp.origin : origin;
           if (await checkOrAskPermission(host, METHODS.subscribeAddress)) {
-            return getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!.address;
+            return getLastActiveProtocolAccount(PROTOCOLS.aeternity)!.address;
           }
           return Promise.reject(new RpcRejectedByUserError('Rejected by user'));
         },

--- a/src/composables/fungibleTokens.ts
+++ b/src/composables/fungibleTokens.ts
@@ -11,7 +11,7 @@ import type {
   ITransaction,
   TokenPair,
 } from '@/types';
-import { PROTOCOL_AETERNITY, STORAGE_KEYS, TX_DIRECTION } from '@/constants';
+import { PROTOCOLS, STORAGE_KEYS, TX_DIRECTION } from '@/constants';
 import FungibleTokenFullInterfaceACI from '@/lib/contracts/FungibleTokenFullInterfaceACI.json';
 import AedexV2PairACI from '@/lib/contracts/AedexV2PairACI.json';
 import ZeitTokenACI from '@/lib/contracts/FungibleTokenFullACI.json';
@@ -61,7 +61,7 @@ export function useFungibleTokens() {
   } = useAccounts();
 
   function getAccountTokenBalances(address?: string): IToken[] {
-    const account = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
     return tokenBalances.value[address || account?.address!] || [];
   }
 
@@ -119,7 +119,7 @@ export function useFungibleTokens() {
 
   async function createOrChangeAllowance(contractId: string, amount: number | string) {
     const aeSdk = await getAeSdk();
-    const account = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
     const selectedToken = tokenBalances.value?.[account?.address!]
       ?.find((token) => token?.contractId === contractId);
 
@@ -159,7 +159,7 @@ export function useFungibleTokens() {
   ): Promise<Partial<TokenPair> & Record<string, any>> {
     try {
       const aeSdk = await getAeSdk();
-      const account = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+      const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
       const tokenContract = await aeSdk.initializeContract({
         aci: AedexV2PairACI,
         address,
@@ -257,7 +257,7 @@ export function useFungibleTokens() {
 
     // This is out of place but since we are treating new protocols as fungible tokens
     // it is better to have it here than in the protocol specific helper file
-    if (transaction.protocol && transaction.protocol !== PROTOCOL_AETERNITY) {
+    if (transaction.protocol && transaction.protocol !== PROTOCOLS.aeternity) {
       return new BigNumber(
         transaction.tx?.amount || 0,
       )
@@ -290,8 +290,8 @@ export function useFungibleTokens() {
   }
 
   onNetworkChange(async (network, oldNetwork) => {
-    const newMiddlewareUrl = network.protocols[PROTOCOL_AETERNITY].middlewareUrl;
-    const oldMiddlewareUrl = oldNetwork?.protocols?.[PROTOCOL_AETERNITY]?.middlewareUrl;
+    const newMiddlewareUrl = network.protocols[PROTOCOLS.aeternity].middlewareUrl;
+    const oldMiddlewareUrl = oldNetwork?.protocols?.[PROTOCOLS.aeternity]?.middlewareUrl;
     if (newMiddlewareUrl !== oldMiddlewareUrl) {
       await loadAvailableTokens();
       await loadTokenBalances();

--- a/src/composables/maxAmount.ts
+++ b/src/composables/maxAmount.ts
@@ -25,7 +25,7 @@ import {
   handleUnknownError,
   isUrlValid,
 } from '@/utils';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   STUB_CALLDATA,
   STUB_CONTRACT_ADDRESS,
@@ -70,7 +70,7 @@ export function useMaxAmount({ formModel }: MaxAmountOptions) {
   });
 
   function getAccount() {
-    return getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!;
+    return getLastActiveProtocolAccount(PROTOCOLS.aeternity)!;
   }
 
   watch(

--- a/src/composables/networks.ts
+++ b/src/composables/networks.ts
@@ -9,7 +9,7 @@ import {
   NETWORK_NAME_TESTNET,
   NETWORK_TYPE_MAINNET,
   NETWORK_TYPE_TESTNET,
-  PROTOCOLS,
+  PROTOCOL_LIST,
   STORAGE_KEYS,
 } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -54,7 +54,7 @@ function ensureDefaultNetworksExists() {
     networkTypes.forEach((type) => {
       defaultNetworks.push({
         name: (type === NETWORK_TYPE_MAINNET) ? NETWORK_NAME_MAINNET : NETWORK_NAME_TESTNET,
-        protocols: PROTOCOLS.reduce((accumulator, protocol) => {
+        protocols: PROTOCOL_LIST.reduce((accumulator, protocol) => {
           // eslint-disable-next-line no-param-reassign
           accumulator[protocol] = ProtocolAdapterFactory.getAdapter(protocol)
             .getNetworkTypeDefaultValues(type);

--- a/src/composables/notifications.ts
+++ b/src/composables/notifications.ts
@@ -15,7 +15,7 @@ import {
   NOTIFICATION_STATUS_READ,
   NOTIFICATION_ENTITY_TYPE_TIP,
   AGGREGATOR_URL,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   STORAGE_KEYS,
   NOTIFICATION_TYPES,
 } from '@/constants';
@@ -91,7 +91,7 @@ export function useNotifications({
 
   async function fetchAllNotifications(): Promise<INotification[]> {
     // TODO: Remove this condition once global filter is ready
-    if (activeAccount.value.protocol !== PROTOCOL_AETERNITY) {
+    if (activeAccount.value.protocol !== PROTOCOLS.aeternity) {
       return [];
     }
 

--- a/src/composables/tokensList.ts
+++ b/src/composables/tokensList.ts
@@ -11,7 +11,7 @@ import type {
 } from '@/types';
 import { AE_CONTRACT_ID } from '@/protocols/aeternity/config';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useCurrencies } from './currencies';
 import { useFungibleTokens } from './fungibleTokens';
 import { useAccounts } from './accounts';
@@ -72,7 +72,7 @@ export function useTokensList({
    */
   const aeToken = computed(
     (): ICoin => ProtocolAdapterFactory
-      .getAdapter(PROTOCOL_AETERNITY)
+      .getAdapter(PROTOCOLS.aeternity)
       .getDefaultCoin(marketData.value!, +aeTokenBalance.value),
   );
 

--- a/src/composables/transactionList.ts
+++ b/src/composables/transactionList.ts
@@ -12,7 +12,7 @@ import type {
   IAccountTransactionsState,
 } from '@/types';
 import {
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   TRANSACTIONS_LOCAL_STORAGE_KEY,
   TXS_PER_PAGE,
 } from '@/constants';
@@ -99,7 +99,7 @@ export function useTransactionList() {
 
   function setPendingTransactionSentByHash(address: Encoded.AccountAddress, hash: string) {
     if (transactions.value[address].localPendingTransaction !== null
-        && transactions.value[address].localPendingTransaction?.hash === hash
+      && transactions.value[address].localPendingTransaction?.hash === hash
     ) {
       (transactions.value[address].localPendingTransaction as ITransaction).sent = true;
     }
@@ -138,7 +138,7 @@ export function useTransactionList() {
     isMultisig?: boolean,
   ): Promise<ITransaction[]> {
     const { protocol } = isMultisig
-      ? { protocol: PROTOCOL_AETERNITY as Protocol }
+      ? { protocol: PROTOCOLS.aeternity as Protocol }
       : getAccountByAddress(address) || {};
     await getAeSdk(); // Ensure the `nodeNetworkId` is established
 

--- a/src/composables/transactionTokens.ts
+++ b/src/composables/transactionTokens.ts
@@ -5,7 +5,7 @@ import type {
   ITransaction,
   TxFunctionParsed,
 } from '@/types';
-import { PROTOCOL_AETERNITY, TX_DIRECTION } from '@/constants';
+import { PROTOCOLS, TX_DIRECTION } from '@/constants';
 import { toShiftedBigNumber } from '@/utils';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import {
@@ -63,7 +63,7 @@ export function useTransactionTokens({
       }));
     }
 
-    if (transaction.protocol && transaction.protocol !== PROTOCOL_AETERNITY) {
+    if (transaction.protocol && transaction.protocol !== PROTOCOLS.aeternity) {
       const protocolAdapter = ProtocolAdapterFactory
         .getAdapter(transaction.protocol);
       return [{

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -8,15 +8,13 @@ export const MOBILE_WIDTH = 480;
 
 export const LOCAL_STORAGE_PREFIX = 'sh-wallet';
 
-export const PROTOCOL_AETERNITY = 'aeternity';
-export const PROTOCOL_BITCOIN = 'bitcoin';
-export const PROTOCOL_ETHEREUM = 'ethereum';
+export const PROTOCOLS = {
+  aeternity: 'aeternity',
+  bitcoin: 'bitcoin',
+  ethereum: 'ethereum',
+} as const;
 
-export const PROTOCOLS = [
-  PROTOCOL_AETERNITY,
-  PROTOCOL_BITCOIN,
-  PROTOCOL_ETHEREUM,
-] as const;
+export const PROTOCOL_LIST = Object.values(PROTOCOLS);
 
 export const PROTOCOL_VIEW_ACCOUNT_DETAILS = 'AccountDetails';
 export const PROTOCOL_VIEW_ACCOUNT_DETAILS_TRANSACTIONS = 'AccountDetailsTransactions';

--- a/src/constants/stubs.ts
+++ b/src/constants/stubs.ts
@@ -25,7 +25,7 @@ import {
   POPUP_TYPE_MESSAGE_SIGN,
   POPUP_TYPE_RAW_SIGN,
   POPUP_TYPE_SIGN,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from './common';
 
 export const STUB_ADDRESS: Encoded.AccountAddress = 'ak_enAPooFqpTQKkhJmU47J16QZu9HbPQQPwWBVeGnzDbDnv9dxp';
@@ -40,7 +40,7 @@ export const STUB_TIPPING_CONTRACT_ID_V2 = 'ct_2ZEoCKcqXkbz2uahRrsWeaPooZs9SdCv6
 export const STUB_ACCOUNT = {
   mnemonic: 'media view gym mystery all fault truck target envelope kit drop fade',
   address: 'ak_2fxchiLvnj9VADMAXHBiKPsaCEsTFehAspcmWJ3ZzF3pFK1hB5' as Encoded.AccountAddress,
-  protocol: PROTOCOL_AETERNITY,
+  protocol: PROTOCOLS.aeternity,
 };
 
 export const recipientId: Encoded.AccountAddress = 'ak_2ELPCWzcTdiyYuumjaV4D7kE843d1Ts27zH1Y2LBMKDbNtfq1Q';
@@ -152,7 +152,7 @@ export const STUB_TX_PARAMS = {
 
 export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITransaction>>> = {
   spend: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 10000000000000,
       arguments: [],
@@ -165,7 +165,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   tip: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 10000000000000000,
       arguments: [
@@ -186,7 +186,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   retip: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 200000000000000000,
       arguments: [
@@ -203,7 +203,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   tipToken: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 0,
       arguments: [
@@ -232,7 +232,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   retipToken: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 0,
       arguments: [
@@ -257,7 +257,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   claim: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     claim: true,
     tx: {
       amount: 0,
@@ -283,7 +283,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   transfer: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 0,
       arguments: [
@@ -304,7 +304,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   createAllowance: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 0,
       arguments: [
@@ -325,7 +325,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   changeAllowance: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       amount: 0,
       fee: 16780000000000,
@@ -345,7 +345,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   namePreclaim: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       accountId: STUB_ADDRESS,
       commitmentId: 'cm_21m1rLtN2fNT3ovBbWBQo88rPUhbmWWv6L96Z8KH2YGiEkabtZ',
@@ -354,7 +354,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   nameClaim: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       accountId: STUB_ADDRESS,
       fee: 16560000000000,
@@ -365,7 +365,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   nameTransfer: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       accountId: STUB_ADDRESS,
       fee: 17340000000000,
@@ -376,7 +376,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     },
   },
   incompleteTransfer: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     incomplete: true,
     tx: {
       amount: 195697771897021980,
@@ -390,7 +390,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   pendingSpend: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     pending: true,
     tx: {
       amount: 743000000000000000,
@@ -401,7 +401,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   pendingTransfer: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     pending: true,
     tx: {
       amount: 195697771897021980,
@@ -414,7 +414,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   pendingTipAe: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     pending: true,
     tx: {
       amount: 195697771897021980,
@@ -427,7 +427,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   pendingTipToken: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     pending: true,
     tipUrl: 'http://superhero.com',
     tx: {
@@ -441,7 +441,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   payForGaAttach: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       fee: 5560000000000,
       tx: {
@@ -455,7 +455,7 @@ export const STUB_TRANSACTIONS: Partial<Record<TxFunctionParsed, PartialDeep<ITr
     microTime: new Date().getTime(),
   },
   gaMetaSpend: {
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     tx: {
       fee: 76440000000000,
       gaId: STUB_ADDRESS,

--- a/src/lib/ProtocolAdapterFactory.ts
+++ b/src/lib/ProtocolAdapterFactory.ts
@@ -4,7 +4,7 @@ import type {
   Protocol,
   ProtocolRecord,
 } from '@/types';
-import { PROTOCOLS } from '@/constants';
+import { PROTOCOL_LIST } from '@/constants';
 import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
 
 /**
@@ -43,7 +43,7 @@ export const ProtocolAdapterFactory = (() => {
     address: string,
     networkType?: NetworkType,
   ): BaseProtocolAdapter | undefined {
-    return PROTOCOLS.reduce((returnData, protocol) => {
+    return PROTOCOL_LIST.reduce((returnData, protocol) => {
       if (!returnData) {
         const adapter = getAdapter(protocol);
         if (adapter.isAccountAddressValid(address, networkType)) {

--- a/src/lib/RouteQueryActionsController.ts
+++ b/src/lib/RouteQueryActionsController.ts
@@ -4,8 +4,8 @@ import { useAccounts, useModals } from '@/composables';
 import {
   APP_LINK_WEB,
   MODAL_TRANSFER_SEND,
+  PROTOCOL_LIST,
   PROTOCOLS,
-  PROTOCOL_AETERNITY,
 } from '@/constants';
 import { ROUTE_NETWORK_ADD } from '@/popup/router/routeNames';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -52,7 +52,7 @@ export const RouteQueryActionsController = (() => {
       // Determine the active protocol for the current transfer
       const token = query[TOKEN_PROP];
 
-      const currentActionProtocol = PROTOCOLS.find((protocol) => {
+      const currentActionProtocol = PROTOCOL_LIST.find((protocol) => {
         const adapter = ProtocolAdapterFactory.getAdapter(protocol);
         return adapter.getUrlTokenKey() === token;
       });
@@ -64,7 +64,7 @@ export const RouteQueryActionsController = (() => {
        * Bitcoin: https://wallet...?op=transferSend&token=bitcoin&amount=0.0002103&account=
        * AEX9 tokens: https://wallet...?op=transferSend&token=ct_mijZGKXeqQBS1dDmdJbbrDzKRrP58XLjJ2u5edkwafzfcXMsY&amount=1&account=
        */
-      setActiveAccountByProtocol(currentActionProtocol || PROTOCOL_AETERNITY);
+      setActiveAccountByProtocol(currentActionProtocol || PROTOCOLS.aeternity);
 
       openModal(MODAL_TRANSFER_SEND);
       return true;

--- a/src/migrations/001-accounts-vuex-to-composable.ts
+++ b/src/migrations/001-accounts-vuex-to-composable.ts
@@ -1,5 +1,5 @@
 import type { IAccountRaw, Migration } from '@/types';
-import { ACCOUNT_HD_WALLET, PROTOCOLS } from '@/constants';
+import { ACCOUNT_HD_WALLET, PROTOCOL_LIST } from '@/constants';
 import { collectVuexState } from './migrationHelpers';
 
 const migration: Migration<IAccountRaw[]> = async (restoredValue: IAccountRaw[]) => {
@@ -8,7 +8,7 @@ const migration: Migration<IAccountRaw[]> = async (restoredValue: IAccountRaw[])
     if (accounts?.length) {
       return accounts.reduce(
         (list: IAccountRaw[], { protocol, type }: IAccountRaw) => {
-          if (PROTOCOLS.includes(protocol) && type === ACCOUNT_HD_WALLET) {
+          if (PROTOCOL_LIST.includes(protocol) && type === ACCOUNT_HD_WALLET) {
             list.push({
               isRestored: true,
               protocol,

--- a/src/popup/components/AccountCard.vue
+++ b/src/popup/components/AccountCard.vue
@@ -20,7 +20,7 @@
 
     <template #bottom>
       <AccountCardTotalTokens
-        v-if="account.protocol === PROTOCOL_AETERNITY"
+        v-if="account.protocol === PROTOCOLS.aeternity"
         :current-account="account"
       />
     </template>
@@ -34,7 +34,7 @@ import {
   PropType,
 } from 'vue';
 import { IAccount } from '@/types';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useBalances } from '@/composables';
 
 import AccountInfo from './AccountInfo.vue';
@@ -59,7 +59,7 @@ export default defineComponent({
     const numericBalance = computed<number>(() => balance.value.toNumber());
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       numericBalance,
     };
   },

--- a/src/popup/components/AccountCardMultisig.vue
+++ b/src/popup/components/AccountCardMultisig.vue
@@ -12,7 +12,7 @@
     <template #middle>
       <BalanceInfo
         :balance="+account.balance"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
       />
     </template>
 
@@ -34,7 +34,7 @@ import {
   PropType,
 } from 'vue';
 import type { IMultisigAccount } from '@/types';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useMultisigAccounts } from '@/composables';
 import { convertMultisigAccountToAccount } from '@/protocols/aeternity/helpers';
 
@@ -66,7 +66,7 @@ export default defineComponent({
     );
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       isPendingAccount,
       convertMultisigAccountToAccount,
     };

--- a/src/popup/components/AccountSwiper.vue
+++ b/src/popup/components/AccountSwiper.vue
@@ -74,7 +74,7 @@ import { Swiper, SwiperSlide } from 'swiper/vue';
 import SwiperCore from 'swiper';
 import { Virtual } from 'swiper/modules';
 import { getAddressColor } from '@/utils';
-import { IS_MOBILE_APP, PROTOCOL_AETERNITY } from '@/constants';
+import { IS_MOBILE_APP, PROTOCOLS } from '@/constants';
 
 import AccountCardAdd from './AccountCardAdd.vue';
 import AccountSwiperSlide from './AccountSwiperSlide.vue';
@@ -138,7 +138,7 @@ export default defineComponent({
 
     return {
       IS_MOBILE_APP,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       currentIdx,
       customSwiper,
       getAccountColor,

--- a/src/popup/components/AuctionOverview.vue
+++ b/src/popup/components/AuctionOverview.vue
@@ -4,7 +4,7 @@
       <template #value>
         <TokenAmount
           :amount="amount"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
         />
       </template>
     </DetailsItem>
@@ -21,7 +21,7 @@
 import { computed, defineComponent } from 'vue';
 import { blocksToRelativeTime } from '@/utils';
 import { useTopHeaderData } from '@/composables';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
 import DetailsItem from './DetailsItem.vue';
@@ -46,7 +46,7 @@ export default defineComponent({
     const endHeight = computed(() => blocksToRelativeTime(blocksToExpiry.value));
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       blocksToRelativeTime,
       auction,
       amount,

--- a/src/popup/components/AuthorizedAccounts.vue
+++ b/src/popup/components/AuthorizedAccounts.vue
@@ -12,7 +12,7 @@
         >
           <AccountItem
             :address="address"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
           <DialogBox
             v-if="isLocalAccountAddress(address)"
@@ -29,7 +29,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useAccounts } from '../../composables';
 
 import DetailsItem from './DetailsItem.vue';
@@ -54,7 +54,7 @@ export default defineComponent({
 
     return {
       isLocalAccountAddress,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
     };
   },
 });

--- a/src/popup/components/DashboardHeaderMultisig.vue
+++ b/src/popup/components/DashboardHeaderMultisig.vue
@@ -29,7 +29,7 @@ import {
   defineComponent,
 } from 'vue';
 import BigNumber from 'bignumber.js';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   useCurrencies,
   useMultisigAccounts,
@@ -69,7 +69,7 @@ export default defineComponent({
           .reduce((total, balance) => total.plus(balance), new BigNumber(0))
           .toFixed();
 
-        return getFiat(+totalBalance, PROTOCOL_AETERNITY);
+        return getFiat(+totalBalance, PROTOCOLS.aeternity);
       },
     );
 

--- a/src/popup/components/FungibleTokens/TokensListItem.vue
+++ b/src/popup/components/FungibleTokens/TokensListItem.vue
@@ -21,10 +21,10 @@
         bright
       />
       <TokenAmount
-        :amount="+tokenData.convertedBalance || 0"
+        :amount="+(tokenData.convertedBalance ?? 0)"
         :symbol="tokenData.symbol"
         :aex9="isTokenAeCoin"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         dynamic-sizing
         no-symbol
         hide-fiat
@@ -48,7 +48,7 @@
 import { computed, defineComponent, PropType } from 'vue';
 import type { IToken } from '@/types';
 import { AE_CONTRACT_ID } from '@/protocols/aeternity/config';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useCurrencies } from '@/composables';
 import { ROUTE_COIN, ROUTE_MULTISIG_COIN, ROUTE_TOKEN } from '@/popup/router/routeNames';
 
@@ -79,9 +79,9 @@ export default defineComponent({
     /**
      * price and balanceFormatted are applicable only for AE Coin
      */
-    const price = computed(() => formatCurrency(getCurrentCurrencyRate(PROTOCOL_AETERNITY)));
+    const price = computed(() => formatCurrency(getCurrentCurrencyRate(PROTOCOLS.aeternity)));
     const balanceFormatted = computed(
-      () => getFormattedFiat(props.tokenData.convertedBalance || 0, PROTOCOL_AETERNITY),
+      () => getFormattedFiat(props.tokenData.convertedBalance || 0, PROTOCOLS.aeternity),
     );
 
     const isTokenAeCoin = computed(() => props.tokenData.contractId === AE_CONTRACT_ID);
@@ -97,7 +97,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       isTokenAeCoin,
       price,
       targetRouteName,

--- a/src/popup/components/InviteItem.vue
+++ b/src/popup/components/InviteItem.vue
@@ -3,7 +3,7 @@
     <div class="invite-info">
       <TokenAmount
         :amount="inviteLinkBalance"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
       />
       <span class="date">{{ formatDate(createdAt) }}</span>
     </div>
@@ -55,7 +55,7 @@
           class="input-amount"
           :label="$t('pages.invite.top-up-with')"
           :message="errorMessage"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
           readonly
         />
         <div class="centered-buttons">
@@ -96,7 +96,7 @@ import type { IFormModel } from '@/types';
 import { formatDate } from '@/utils';
 import {
   APP_LINK_WEB,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import { ROUTE_INVITE_CLAIM } from '@/popup/router/routeNames';
 import {
@@ -138,7 +138,7 @@ export default defineComponent({
     const formModel = ref<IFormModel>({
       amount: '',
       selectedAsset: ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_AETERNITY)
+        .getAdapter(PROTOCOLS.aeternity)
         .getDefaultCoin(marketData.value!, +balance.value),
     });
     const { max } = useMaxAmount({ formModel });
@@ -179,7 +179,7 @@ export default defineComponent({
       try {
         await claimInvite({
           secretKey: Buffer.from(props.secretKey),
-          recipientId: getLastActiveProtocolAccount(PROTOCOL_AETERNITY)?.address!,
+          recipientId: getLastActiveProtocolAccount(PROTOCOLS.aeternity)?.address!,
           isMax: true,
         });
         await updateBalance();
@@ -231,7 +231,7 @@ export default defineComponent({
     );
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       formModel,
       max,
       topUp,

--- a/src/popup/components/Modals/AccountCreate.vue
+++ b/src/popup/components/Modals/AccountCreate.vue
@@ -17,7 +17,7 @@
       </p>
 
       <BtnSubheader
-        v-for="protocol in PROTOCOLS"
+        v-for="protocol in PROTOCOL_LIST"
         :key="protocol"
         :header="getProtocolName(protocol)"
         :subheader="$t(
@@ -34,10 +34,8 @@ import { defineComponent, onMounted, PropType } from 'vue';
 import type { Protocol, ResolveCallback } from '@/types';
 import {
   MODAL_AE_ACCOUNT_CREATE,
-  PROTOCOL_AETERNITY,
-  PROTOCOL_BITCOIN,
-  PROTOCOL_ETHEREUM,
   PROTOCOLS,
+  PROTOCOL_LIST,
 } from '@/constants';
 import {
   useAccounts,
@@ -70,12 +68,12 @@ export default defineComponent({
 
       // TODO each of the blocks of this switch should be moved to the specific adapter
       switch (protocol) {
-        case PROTOCOL_AETERNITY:
+        case PROTOCOLS.aeternity:
           await openModal(MODAL_AE_ACCOUNT_CREATE);
           break;
 
-        case PROTOCOL_BITCOIN:
-        case PROTOCOL_ETHEREUM:
+        case PROTOCOLS.bitcoin:
+        case PROTOCOLS.ethereum:
           idx = addRawAccount({
             isRestored: false,
             protocol,
@@ -99,9 +97,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOLS,
-      PROTOCOL_AETERNITY,
-      PROTOCOL_BITCOIN,
+      PROTOCOL_LIST,
       isOnline,
       createAccount,
       getProtocolName,

--- a/src/popup/components/Modals/ClaimGiftCard.vue
+++ b/src/popup/components/Modals/ClaimGiftCard.vue
@@ -29,7 +29,7 @@
         <AccountItem
           v-else-if="!isCardEmpty"
           :address="recipientId"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
         />
       </template>
     </DetailsItem>
@@ -39,7 +39,7 @@
       </span>
       <BalanceInfo
         :balance="balance.toNumber()"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         :class="{
           gray: balance.toNumber() === 0,
         }"
@@ -56,7 +56,7 @@
       v-model="amount"
       :errors="errors"
       readonly
-      :protocol="PROTOCOL_AETERNITY"
+      :protocol="PROTOCOLS.aeternity"
       :custom-label="$t('modals.claimGiftCard.amount')"
       :validation-rules="{
         max_redeem: max.toString(),
@@ -120,7 +120,7 @@ import {
 } from '@/composables';
 import { AE_COIN_PRECISION, AE_SYMBOL } from '@/protocols/aeternity/config';
 import { getAccountFromSecret } from '@/protocols/aeternity/helpers';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import CheckCircleIcon from '@/icons/check-circle.svg?vue-component';
 
 import DetailsItem from '../DetailsItem.vue';
@@ -172,7 +172,7 @@ export default defineComponent({
     const isCardEmpty = ref(false);
     const loading = ref(false);
 
-    const currencyFormatted = computed(() => getFormattedFiat(+amount.value, PROTOCOL_AETERNITY));
+    const currencyFormatted = computed(() => getFormattedFiat(+amount.value, PROTOCOLS.aeternity));
     const mainButtonText = computed(() => {
       switch (step.value) {
         case STEPS.initial:
@@ -283,7 +283,7 @@ export default defineComponent({
       loading,
       mainButtonText,
       max,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       recipientId,
       setMaxAmount,
       step,

--- a/src/popup/components/Modals/ConfirmRawSign.vue
+++ b/src/popup/components/Modals/ConfirmRawSign.vue
@@ -57,7 +57,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, onUnmounted } from 'vue';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { RejectedByUserError } from '@/lib/errors';
 import { useAccounts, usePopupProps } from '@/composables';
 
@@ -82,7 +82,7 @@ export default defineComponent({
     const { popupProps, sender, setPopupProps } = usePopupProps();
     const { getLastActiveProtocolAccount } = useAccounts();
 
-    const activeAccount = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const activeAccount = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
 
     const dataAsString = computed((): string => popupProps.value?.txBase64?.toString() || '');
 

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -40,7 +40,7 @@
         <template #value>
           <TokenAmount
             :amount="nameAeFee"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </template>
       </DetailsItem>
@@ -55,7 +55,7 @@
             :symbol="tokenSymbol"
             :aex9="isTransactionAex9(transactionWrapped)"
             :hide-fiat="!swapTokenAmountData.isAe"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             data-cy="total"
           />
         </DetailsItem>
@@ -63,7 +63,7 @@
         <DetailsItem :label="$t('transaction.fee')">
           <TokenAmount
             :amount="txAeFee"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             data-cy="fee"
           />
         </DetailsItem>
@@ -76,7 +76,7 @@
             :amount="executionCost || totalAmount"
             :symbol="getTxSymbol(popupProps?.tx)"
             :aex9="isTransactionAex9(transactionWrapped)"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             data-cy="total"
           />
         </DetailsItem>
@@ -143,7 +143,7 @@ import type {
 import { tg } from '@/popup/plugins/i18n';
 import { RejectedByUserError } from '@/lib/errors';
 import {
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   TX_DIRECTION,
 } from '@/constants';
 import {
@@ -248,7 +248,7 @@ export default defineComponent({
     const txAeFee = computed(() => getAeFee(popupProps.value?.tx?.fee!));
     const nameAeFee = computed(() => getAeFee(popupProps.value?.tx?.nameFee!));
 
-    const activeAccount = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const activeAccount = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
 
     const swapDirection = computed(() => {
       if (isMaxSpent.value) {
@@ -469,7 +469,7 @@ export default defineComponent({
     return {
       AnimatedSpinner,
       AE_SYMBOL,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       TX_FIELDS_TO_DISPLAY,
       error,
       executionCost,

--- a/src/popup/components/Modals/MultisigProposalConfirmActions.vue
+++ b/src/popup/components/Modals/MultisigProposalConfirmActions.vue
@@ -36,7 +36,7 @@
         <div class="active-account">
           <AccountItem
             :address="activeAccount.address"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </div>
 
@@ -90,7 +90,7 @@ import { prepareAccountSelectOptions } from '@/utils';
 import { useAccounts, useMultisigAccounts, usePendingMultisigTransaction } from '@/composables';
 import { TX_FUNCTIONS_MULTISIG } from '@/protocols/aeternity/config';
 
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import Modal from '../Modal.vue';
 import FormSelect from '../form/FormSelect.vue';
 import BtnMain from '../buttons/BtnMain.vue';
@@ -175,7 +175,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       TX_FUNCTIONS_MULTISIG,
       statusIcon,
       closeModal,

--- a/src/popup/components/Modals/MultisigVaultCreate.vue
+++ b/src/popup/components/Modals/MultisigVaultCreate.vue
@@ -37,7 +37,7 @@
           :name="`signer-address-${index}`"
           :rules="{
             required: true,
-            account_address: [PROTOCOL_AETERNITY],
+            account_address: [PROTOCOLS.aeternity],
           }"
         >
           <FormTextarea
@@ -188,7 +188,7 @@ import { Encoded } from '@aeternity/aepp-sdk';
 
 import {
   MODAL_READ_QR_CODE,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   excludeFalsy,
@@ -430,7 +430,7 @@ export default defineComponent({
       PlusCircleIcon,
       MULTISIG_VAULT_MIN_NUM_OF_SIGNERS,
       MULTISIG_CREATION_PHASES,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       STEPS,
       currentMultisigAccountId,
       aeAccountsSelectOptions,

--- a/src/popup/components/Modals/RecipientInfo.vue
+++ b/src/popup/components/Modals/RecipientInfo.vue
@@ -76,7 +76,7 @@ import {
   ResolveCallback,
 } from '@/types';
 import { AE_BLOG_CLAIM_TIP_URL } from '@/protocols/aeternity/config';
-import { PROTOCOL_AETERNITY, UNFINISHED_FEATURES } from '@/constants';
+import { PROTOCOLS, UNFINISHED_FEATURES } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import Default from './Default.vue';
 import BtnMain from '../buttons/BtnMain.vue';
@@ -92,7 +92,7 @@ export default defineComponent({
     close: { type: Function, default: null },
   },
   setup(props) {
-    const isProtocolAe = computed(() => props.protocol === PROTOCOL_AETERNITY);
+    const isProtocolAe = computed(() => props.protocol === PROTOCOLS.aeternity);
     const protocolName = computed(
       () => ProtocolAdapterFactory.getAdapter(props.protocol).protocolName,
     );

--- a/src/popup/components/Modals/TransferReceiveBase.vue
+++ b/src/popup/components/Modals/TransferReceiveBase.vue
@@ -109,8 +109,7 @@ import type {
 } from '@/types';
 import {
   IS_MOBILE_DEVICE,
-  PROTOCOL_BITCOIN,
-  PROTOCOL_ETHEREUM,
+  PROTOCOLS,
 } from '@/constants';
 import { RouteQueryActionsController } from '@/lib/RouteQueryActionsController';
 import { useAccounts, useCopy } from '@/composables';
@@ -238,8 +237,7 @@ export default defineComponent({
     })();
 
     return {
-      PROTOCOL_BITCOIN,
-      PROTOCOL_ETHEREUM,
+      PROTOCOLS,
       IS_MOBILE_DEVICE,
       ShareIcon,
       amount,

--- a/src/popup/components/MultisigProposalConsensus.vue
+++ b/src/popup/components/MultisigProposalConsensus.vue
@@ -33,7 +33,7 @@
         >
           <AccountItem
             :address="signer"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
 
           <CheckCircle
@@ -69,7 +69,7 @@ import { computed, defineComponent } from 'vue';
 import { TranslateResult, useI18n } from 'vue-i18n';
 import {
   MODAL_CONSENSUS_INFO,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   useAccounts,
@@ -184,7 +184,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       activeMultisigAccount,
       isLocalAccountAddress,
       infoBox,

--- a/src/popup/components/MultisigVaultCreateReview.vue
+++ b/src/popup/components/MultisigVaultCreateReview.vue
@@ -43,7 +43,7 @@
           >
             <AccountItem
               :address="signer.address"
-              :protocol="PROTOCOL_AETERNITY"
+              :protocol="PROTOCOLS.aeternity"
             />
             <DialogBox
               v-if="isLocalAccountAddress(signer.address)"
@@ -65,7 +65,7 @@
           <TokenAmount
             :amount="fee"
             :symbol="AE_SYMBOL"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </template>
       </DetailsItem>
@@ -103,7 +103,7 @@ import type {
   ICreateMultisigAccount,
   IMultisigCreationPhase,
 } from '@/types';
-import { MODAL_CONSENSUS_INFO, PROTOCOL_AETERNITY } from '@/constants';
+import { MODAL_CONSENSUS_INFO, PROTOCOLS } from '@/constants';
 import { AE_SYMBOL } from '@/protocols/aeternity/config';
 import { handleUnknownError } from '@/utils';
 import {
@@ -205,7 +205,7 @@ export default defineComponent({
       callData,
       notEnoughBalanceToCreateMultisig,
       openConsensusInfoModal,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
     };
   },
 });

--- a/src/popup/components/NotificationItem.vue
+++ b/src/popup/components/NotificationItem.vue
@@ -32,7 +32,7 @@
       <AddressTruncated
         v-if="!chainName && address"
         :address="address"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         class="address"
       />
       <Truncate
@@ -72,7 +72,7 @@ import {
   IS_MOBILE_DEVICE,
   NOTIFICATION_STATUS_READ,
   NOTIFICATION_TYPES,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
@@ -155,7 +155,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       IS_MOBILE_DEVICE,
       createdAt,
       message,

--- a/src/popup/components/ProtocolIcon.vue
+++ b/src/popup/components/ProtocolIcon.vue
@@ -14,11 +14,7 @@ import {
   defineComponent,
   PropType,
 } from 'vue';
-import {
-  PROTOCOL_AETERNITY,
-  PROTOCOL_BITCOIN,
-  PROTOCOL_ETHEREUM,
-} from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import type { Protocol } from '@/types';
 import AeternityIcon from '@/icons/coin/aeternity.svg?vue-component';
 import BitcoinIcon from '@/icons/coin/bitcoin.svg?vue-component';
@@ -42,9 +38,9 @@ export default defineComponent({
   },
   setup(props) {
     const iconsMap: Record<Protocol, Component> = {
-      [PROTOCOL_AETERNITY]: AeternityIcon,
-      [PROTOCOL_BITCOIN]: BitcoinIcon,
-      [PROTOCOL_ETHEREUM]: EthereumIcon,
+      [PROTOCOLS.aeternity]: AeternityIcon,
+      [PROTOCOLS.bitcoin]: BitcoinIcon,
+      [PROTOCOLS.ethereum]: EthereumIcon,
     };
 
     const selectedIcon = computed((): Component => iconsMap[props.protocol]);

--- a/src/popup/components/ProtocolSpecificView.vue
+++ b/src/popup/components/ProtocolSpecificView.vue
@@ -33,7 +33,7 @@ import type {
   ProtocolView,
   ProtocolViewsConfig,
 } from '@/types';
-import { DISTINCT_PROTOCOL_VIEWS, PROTOCOL_AETERNITY } from '@/constants';
+import { DISTINCT_PROTOCOL_VIEWS, PROTOCOLS } from '@/constants';
 import { useAccounts, useNetworks } from '@/composables';
 import Logger from '@/lib/logger';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -86,7 +86,7 @@ export default defineComponent({
 
     const protocol = ((): Protocol => {
       if (routeMeta.isMultisig) {
-        return PROTOCOL_AETERNITY;
+        return PROTOCOLS.aeternity;
       }
       if (transactionOwner) {
         const ownerProtocol = ProtocolAdapterFactory.getAdapterByAccountAddress(

--- a/src/popup/components/SwapRates.vue
+++ b/src/popup/components/SwapRates.vue
@@ -22,7 +22,7 @@
       <div>
         <TokenAmount
           :amount="rate.price"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
           class="price"
           hide-fiat
           no-symbol
@@ -44,7 +44,7 @@ import {
   defineComponent,
   PropType,
 } from 'vue';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { camelCase } from 'lodash-es';
 
 import {
@@ -115,7 +115,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       availableTokens,
       isSwapTx,
       rates,

--- a/src/popup/components/Tokens.vue
+++ b/src/popup/components/Tokens.vue
@@ -49,7 +49,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue';
 import type { ITokenResolved } from '@/types';
-import { PROTOCOL_AETERNITY, PROTOCOL_BITCOIN, PROTOCOL_ETHEREUM } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   truncateString as truncateStringFactory,
 } from '@/utils';
@@ -144,13 +144,13 @@ export default defineComponent({
     const showProtocolIcon = computed(() => PROTOCOL_SYMBOLS.includes(imgToken.value?.symbol!));
     const imgTokenProtocol = computed(() => {
       if (imgToken.value?.isAe || imgToken.value?.contractId === AE_CONTRACT_ID) {
-        return PROTOCOL_AETERNITY;
+        return PROTOCOLS.aeternity;
       }
       if (imgToken.value?.symbol === BTC_SYMBOL) {
-        return PROTOCOL_BITCOIN;
+        return PROTOCOLS.bitcoin;
       }
       if (imgToken.value?.symbol === ETH_SYMBOL) {
-        return PROTOCOL_ETHEREUM;
+        return PROTOCOLS.ethereum;
       }
       return null;
     });

--- a/src/popup/components/TransactionAndTokenFilter.vue
+++ b/src/popup/components/TransactionAndTokenFilter.vue
@@ -42,7 +42,7 @@ import {
   watch,
 } from 'vue';
 import { useRoute } from 'vue-router';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   useAccounts,
   useTransactionAndTokenFilter,
@@ -81,7 +81,7 @@ export default defineComponent({
     const transactionFilterEl = ref<HTMLDivElement>();
     const resizeObserver = ref<ResizeObserver>();
 
-    const isActiveAccountAe = computed(() => activeAccount.value.protocol === PROTOCOL_AETERNITY);
+    const isActiveAccountAe = computed(() => activeAccount.value.protocol === PROTOCOLS.aeternity);
 
     const openHeight = computed(() => (
       props.showFilters

--- a/src/popup/components/TransactionDetailsPoolTokenRow.vue
+++ b/src/popup/components/TransactionDetailsPoolTokenRow.vue
@@ -8,7 +8,7 @@
         <TokenAmount
           v-if="!hideAmount"
           :amount="amount"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
           hide-fiat
           no-symbol
         />
@@ -21,7 +21,7 @@
             v-if="token.contractId"
             show-explorer-link
             :address="token.contractId"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </div>
       </div>
@@ -32,7 +32,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 import { toShiftedBigNumber } from '@/utils';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import DetailsItem from './DetailsItem.vue';
 import TokenAmount from './TokenAmount.vue';
 import Tokens from './Tokens.vue';
@@ -71,7 +71,7 @@ export default defineComponent({
     ));
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       amount,
     };
   },

--- a/src/popup/components/TransactionListItem.vue
+++ b/src/popup/components/TransactionListItem.vue
@@ -63,7 +63,7 @@ import type {
   IActiveMultisigTransaction,
   ITransaction,
 } from '@/types';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   amountRounded,
   executeAndSetInterval,
@@ -162,7 +162,7 @@ export default defineComponent({
               : aeToken.amount
           )!,
         ),
-        PROTOCOL_AETERNITY,
+        PROTOCOLS.aeternity,
       );
     });
 

--- a/src/popup/components/TransferSend/TransferSendRecipient.vue
+++ b/src/popup/components/TransferSend/TransferSendRecipient.vue
@@ -55,7 +55,7 @@ import { Field } from 'vee-validate';
 
 import type { Protocol, IInputMessage } from '@/types';
 import { getMessageByFieldName } from '@/utils';
-import { MODAL_RECIPIENT_INFO, PROTOCOL_AETERNITY } from '@/constants';
+import { MODAL_RECIPIENT_INFO, PROTOCOLS } from '@/constants';
 import {
   useAccounts,
   useModals,
@@ -83,7 +83,7 @@ export default defineComponent({
   },
   emits: ['openQrModal', 'update:modelValue'],
   setup(props) {
-    const isAe = computed(() => props.protocol === PROTOCOL_AETERNITY);
+    const isAe = computed(() => props.protocol === PROTOCOLS.aeternity);
 
     const { openModal } = useModals();
     const { activeAccount } = useAccounts();

--- a/src/popup/pages/AccountDetailsMultisig.vue
+++ b/src/popup/pages/AccountDetailsMultisig.vue
@@ -17,7 +17,7 @@
         <template #balance>
           <BalanceInfo
             :balance="+(activeMultisigAccount.balance || 0)"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </template>
 
@@ -43,7 +43,7 @@
 <script lang="ts">
 import { IonContent, IonPage } from '@ionic/vue';
 import { computed, defineComponent } from 'vue';
-import { PROTOCOL_AETERNITY, UNFINISHED_FEATURES } from '@/constants';
+import { PROTOCOLS, UNFINISHED_FEATURES } from '@/constants';
 import { useMultisigAccounts } from '@/composables';
 import { buildSimplexLink, convertMultisigAccountToAccount } from '@/protocols/aeternity/helpers';
 
@@ -80,7 +80,7 @@ export default defineComponent({
 
     return {
       UNFINISHED_FEATURES,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       activeMultisigAccount,
       simplexLink,
       CreditCardIcon,

--- a/src/popup/pages/CommentNew.vue
+++ b/src/popup/pages/CommentNew.vue
@@ -41,7 +41,7 @@ import {
 } from 'vue';
 import { RouteLocationNormalized, useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { postJson } from '@/utils';
 import {
   useAccounts,
@@ -82,7 +82,7 @@ export default defineComponent({
       setActiveAccountByAddress,
     } = useAccounts();
 
-    const creatorAddress = ref(getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!.address);
+    const creatorAddress = ref(getLastActiveProtocolAccount(PROTOCOLS.aeternity)!.address);
     const id = ref<string>('');
     const parentId = ref<number | undefined>(undefined);
     const text = ref<string>('');

--- a/src/popup/pages/Dashboard.vue
+++ b/src/popup/pages/Dashboard.vue
@@ -36,7 +36,9 @@
           />
 
           <DashboardCard
-            v-if="(isNodeMainnet || isNodeTestnet) && activeAccount.protocol === PROTOCOL_AETERNITY"
+            v-if="
+              (isNodeMainnet || isNodeTestnet)
+                && activeAccount.protocol === PROTOCOLS.aeternity"
             :title="$t('dashboard.nameCard.title')"
             :description="$t('dashboard.nameCard.description')"
             :btn-text="$t('dashboard.nameCard.button')"
@@ -64,7 +66,7 @@ import { useRoute } from 'vue-router';
 import {
   DASHBOARD_CARD_ID,
   IS_MOBILE_APP,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   UNFINISHED_FEATURES,
 } from '@/constants';
 import { ROUTE_ACCOUNT_DETAILS_NAMES_CLAIM, ROUTE_APPS_BROWSER } from '@/popup/router/routeNames';
@@ -122,7 +124,7 @@ export default defineComponent({
     );
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       DASHBOARD_CARD_ID,
       UNFINISHED_FEATURES,
       ROUTE_ACCOUNT_DETAILS_NAMES_CLAIM,

--- a/src/popup/pages/FungibleTokens/TokenContainer.vue
+++ b/src/popup/pages/FungibleTokens/TokenContainer.vue
@@ -15,7 +15,7 @@
               no-symbol
               fiat-below
               large
-              :protocol="PROTOCOL_AETERNITY"
+              :protocol="PROTOCOLS.aeternity"
               :amount="convertedBalance"
               :aex9="!isAe"
             />
@@ -104,7 +104,7 @@ import { Encoded } from '@aeternity/aepp-sdk';
 import type { IToken, TokenPair } from '@/types';
 import {
   IS_IOS,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   UNFINISHED_FEATURES,
   IS_FIREFOX,
 } from '@/constants';
@@ -221,7 +221,7 @@ export default defineComponent({
     const tokenData = computed((): IToken => {
       if (isAe) {
         return ProtocolAdapterFactory
-          .getAdapter(PROTOCOL_AETERNITY)
+          .getAdapter(PROTOCOLS.aeternity)
           .getDefaultCoin(marketData.value!, aeTokenBalance.value.toNumber());
       }
       return getAccountTokenBalances().find(
@@ -283,7 +283,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       UNFINISHED_FEATURES,
       IS_IOS,
       AE_DEX_URL,

--- a/src/popup/pages/FungibleTokens/TokenDetails.vue
+++ b/src/popup/pages/FungibleTokens/TokenDetails.vue
@@ -27,7 +27,7 @@
           <template #text>
             <AddressTruncated
               show-explorer-link
-              :protocol="PROTOCOL_AETERNITY"
+              :protocol="PROTOCOLS.aeternity"
               :address="tokenData.contractId"
             />
           </template>
@@ -168,7 +168,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { IonContent, IonPage } from '@ionic/vue';
 import {
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   UNFINISHED_FEATURES,
 } from '@/constants';
 import {
@@ -228,7 +228,7 @@ export default defineComponent({
     );
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       AE_DEX_URL,
       UNFINISHED_FEATURES,
       displayDexUrl,

--- a/src/popup/pages/Index.vue
+++ b/src/popup/pages/Index.vue
@@ -99,7 +99,7 @@ import {
   IS_WEB,
   IS_IOS,
   MODAL_ACCOUNT_IMPORT,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   useAccounts,
@@ -135,7 +135,7 @@ export default defineComponent({
       setGeneratedMnemonic();
       addRawAccount({
         isRestored: false,
-        protocol: PROTOCOL_AETERNITY,
+        protocol: PROTOCOLS.aeternity,
       });
       router.push(loginTargetLocation.value);
     }

--- a/src/popup/pages/Invite.vue
+++ b/src/popup/pages/Invite.vue
@@ -33,7 +33,7 @@
             :label="$t('pages.invite.tip-attached')"
             :message="errorMessage"
             readonly
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             :selected-asset="formModel.selectedAsset"
             @asset-selected="(val) => formModel.selectedAsset = val"
           />
@@ -56,7 +56,7 @@
           <InviteItem
             v-for="link in invites"
             v-bind="link ?? null"
-            :key="link.secretKey"
+            :key="link.secretKey.toString()"
             @loading="(val) => setLoaderVisible(val)"
           />
         </div>
@@ -73,7 +73,7 @@ import { generateKeyPair, AE_AMOUNT_FORMATS } from '@aeternity/aepp-sdk';
 
 import type { IFormModel } from '@/types';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import {
   useAccounts,
   useAeSdk,
@@ -113,7 +113,7 @@ export default defineComponent({
     const formModel = ref<IFormModel>({
       amount: '',
       selectedAsset: ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_AETERNITY)
+        .getAdapter(PROTOCOLS.aeternity)
         .getDefaultCoin(marketData.value!, +balance.value),
     });
 
@@ -145,7 +145,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       PlusCircleFillIcon,
       activeAccount,
       balance,

--- a/src/popup/pages/More.vue
+++ b/src/popup/pages/More.vue
@@ -89,7 +89,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 import { IonContent, IonPage } from '@ionic/vue';
-import { BUG_REPORT_URL, PROTOCOL_AETERNITY, UNFINISHED_FEATURES } from '@/constants';
+import { BUG_REPORT_URL, PROTOCOLS, UNFINISHED_FEATURES } from '@/constants';
 import { useAccounts, useAeSdk } from '@/composables';
 import { AE_DEX_URL, AE_SIMPLEX_URL } from '@/protocols/aeternity/config';
 import { buildAeFaucetUrl } from '@/protocols/aeternity/helpers';
@@ -123,7 +123,7 @@ export default defineComponent({
     const { activeAccount } = useAccounts();
     const { isNodeMainnet, isNodeTestnet } = useAeSdk();
 
-    const isActiveAccountAe = computed(() => activeAccount.value.protocol === PROTOCOL_AETERNITY);
+    const isActiveAccountAe = computed(() => activeAccount.value.protocol === PROTOCOLS.aeternity);
     const activeAccountFaucetUrl = computed(
       () => (isActiveAccountAe.value) ? buildAeFaucetUrl(activeAccount.value.address) : null,
     );

--- a/src/popup/pages/MultisigProposalDetails.vue
+++ b/src/popup/pages/MultisigProposalDetails.vue
@@ -74,7 +74,7 @@
                   <div class="row">
                     <AccountItem
                       :address="activeMultisigAccount.proposedBy"
-                      :protocol="PROTOCOL_AETERNITY"
+                      :protocol="PROTOCOLS.aeternity"
                     />
                     <DialogBox
                       v-if="isLocalAccountAddress(activeMultisigAccount.proposedBy)"
@@ -137,7 +137,7 @@
                 <template #value>
                   <TokenAmount
                     :amount="+(aettosToAe(multisigTx.gasPrice))"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                     :symbol="AE_SYMBOL"
                     hide-fiat
                   />
@@ -151,7 +151,7 @@
                   <TokenAmount
                     :amount="+aettosToAe(transaction.tx.gasPrice)"
                     :symbol="AE_SYMBOL"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                   />
                 </template>
               </DetailsItem>
@@ -169,7 +169,7 @@
                   <TokenAmount
                     :amount="+aettosToAe(multisigTx.fee)"
                     :symbol="AE_SYMBOL"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                   />
                 </template>
               </DetailsItem>
@@ -182,7 +182,7 @@
                   <TokenAmount
                     :amount="+aettosToAe(transaction.tx.fee)"
                     :symbol="AE_SYMBOL"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                   />
                 </template>
               </DetailsItem>
@@ -196,7 +196,7 @@
                   <TokenAmount
                     :amount="+aettosToAe(totalSpent)"
                     :symbol="AE_SYMBOL"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                     high-precision
                   />
                 </template>
@@ -292,7 +292,7 @@ import type {
 } from '@/types';
 import {
   MODAL_MULTISIG_PROPOSAL_CONFIRM_ACTION,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   blocksToRelativeTime,
@@ -529,7 +529,7 @@ export default defineComponent({
 
     return {
       AE_SYMBOL,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       TX_FUNCTIONS_MULTISIG,
       activeMultisigAccount,
       activeMultisigAccountExplorerUrl,

--- a/src/popup/pages/Names/AuctionBid.vue
+++ b/src/popup/pages/Names/AuctionBid.vue
@@ -18,7 +18,7 @@
               v-model="amount"
               name="amount"
               :message="amountError || errorMessage"
-              :protocol="PROTOCOL_AETERNITY"
+              :protocol="PROTOCOLS.aeternity"
               readonly
             />
           </Field>
@@ -27,7 +27,7 @@
               <template #value>
                 <TokenAmount
                   :amount="+txFee"
-                  :protocol="PROTOCOL_AETERNITY"
+                  :protocol="PROTOCOLS.aeternity"
                   hide-fiat
                 />
               </template>
@@ -36,7 +36,7 @@
               <template #value>
                 <TokenAmount
                   :amount="+amountTotal"
-                  :protocol="PROTOCOL_AETERNITY"
+                  :protocol="PROTOCOLS.aeternity"
                 />
               </template>
             </DetailsItem>
@@ -76,7 +76,7 @@ import {
 import { useForm, useFieldError, Field } from 'vee-validate';
 
 import { useModals, useAeSdk, useUi } from '@/composables';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { STUB_ADDRESS, STUB_NONCE } from '@/constants/stubs';
 import {
   AE_AENS_BID_MIN_RATIO,
@@ -169,7 +169,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       amount,
       amountTotal,
       amountError,

--- a/src/popup/pages/Names/AuctionHistory.vue
+++ b/src/popup/pages/Names/AuctionHistory.vue
@@ -10,7 +10,7 @@
           <AccountItem
             :address="highestBid.accountId"
             :name="getName(highestBid.accountId).value"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="protocol"
           />
           <AuctionOverview :name="name" />
         </div>
@@ -21,10 +21,10 @@
         >
           <TokenAmount
             :amount="+bid.nameFee"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="protocol"
           />
           <AccountItem
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="protocol"
             :address="bid.accountId"
             :name="getName(bid.accountId).value"
           />
@@ -38,7 +38,7 @@
 import { IonPage, IonContent } from '@ionic/vue';
 import { defineComponent, computed } from 'vue';
 
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
 import AccountItem from '../../components/AccountItem.vue';
@@ -66,7 +66,7 @@ export default defineComponent({
     );
 
     return {
-      PROTOCOL_AETERNITY,
+      protocol: PROTOCOLS.aeternity,
       getName,
       highestBid,
       previousBids,

--- a/src/popup/pages/Names/AuctionList.vue
+++ b/src/popup/pages/Names/AuctionList.vue
@@ -26,7 +26,7 @@
                 {{ name }}
                 <TokenAmount
                   :amount="getAeFee(lastBid.nameFee)"
-                  :protocol="PROTOCOL_AETERNITY"
+                  :protocol="PROTOCOLS.aeternity"
                 />
               </div>
               <div
@@ -76,7 +76,7 @@ import {
   useTopHeaderData,
 } from '@/composables';
 import { getAeFee } from '@/protocols/aeternity/helpers';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 
 import Filters from '@/popup/components/Filters.vue';
 import NameRow from '@/popup/components/NameRow.vue';
@@ -159,7 +159,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       blocksToRelativeTime,
       loading,
       displayMode,

--- a/src/popup/pages/NetworkForm.vue
+++ b/src/popup/pages/NetworkForm.vue
@@ -128,8 +128,8 @@ import type {
 import {
   NETWORK_NAME_MAX_LENGTH,
   NETWORK_TYPE_CUSTOM,
+  PROTOCOL_LIST,
   PROTOCOLS,
-  PROTOCOL_AETERNITY,
 } from '@/constants';
 import { ROUTE_NETWORK_EDIT, ROUTE_NETWORK_SETTINGS } from '@/popup/router/routeNames';
 import { useNetworks } from '@/composables';
@@ -163,7 +163,7 @@ export default defineComponent({
     /**
      * The form is divided to blocks, where each block has the settings for one protocol.
      */
-    const formStructure: IFormBlock[] = PROTOCOLS.map((protocol) => {
+    const formStructure: IFormBlock[] = PROTOCOL_LIST.map((protocol) => {
       const adapter = ProtocolAdapterFactory.getAdapter(protocol);
       return {
         protocol,
@@ -189,7 +189,7 @@ export default defineComponent({
       ? customNetworks.value.findIndex(({ name }) => name === savedNetworkName)
       : null;
 
-    const emptyNetworkSettings = PROTOCOLS.reduce(
+    const emptyNetworkSettings = PROTOCOL_LIST.reduce(
       (result, protocol) => ({ ...result, [protocol]: {} }),
       {},
     );
@@ -223,7 +223,7 @@ export default defineComponent({
      * Every protocol has it's own default values for each of the setting.
      */
     function fillInFieldsWithDefaultValues() {
-      PROTOCOLS.forEach((protocol) => {
+      PROTOCOL_LIST.forEach((protocol) => {
         const adapter = ProtocolAdapterFactory.getAdapter(protocol);
         const settings = adapter.getNetworkSettings();
         newNetworkProtocols.value[protocol] = settings
@@ -251,7 +251,7 @@ export default defineComponent({
           const val = route.query[key];
 
           if (val && typeof val === 'string') {
-            newNetworkProtocols.value[PROTOCOL_AETERNITY][key] = val;
+            newNetworkProtocols.value[PROTOCOLS.aeternity][key] = val;
             isNetworkPrefilled.value = true;
           }
         });
@@ -266,7 +266,7 @@ export default defineComponent({
       const veeValidateValues: Record<string, string> = {
         name: newNetworkName.value,
       };
-      PROTOCOLS.forEach((protocol) => {
+      PROTOCOL_LIST.forEach((protocol) => {
         const settings = newNetworkProtocols.value[protocol];
         Object.keys(settings).forEach((key) => {
           veeValidateValues[`${protocol}-${key}`] = settings[key];

--- a/src/popup/pages/PermissionManager.vue
+++ b/src/popup/pages/PermissionManager.vue
@@ -99,7 +99,7 @@
                 name="transactionSignLimit"
                 label=" "
                 :selected-asset="selectedAsset"
-                :protocol="PROTOCOL_AETERNITY"
+                :protocol="PROTOCOLS.aeternity"
                 readonly
               />
             </Field>
@@ -108,21 +108,21 @@
               <TokenAmount
                 :label="$t('pages.permissions.spent-today')"
                 :amount="permission.transactionSignSpent"
-                :protocol="PROTOCOL_AETERNITY"
+                :protocol="PROTOCOLS.aeternity"
               />
             </div>
             <div class="limit-info">
               <TokenAmount
                 :label="$t('pages.permissions.left-today')"
                 :amount="permission.transactionSignLimit - permission.transactionSignSpent"
-                :protocol="PROTOCOL_AETERNITY"
+                :protocol="PROTOCOLS.aeternity"
               />
             </div>
             <div class="limit-info">
               <TokenAmount
                 :label="$t('pages.account.balance')"
                 :amount="+balance"
-                :protocol="PROTOCOL_AETERNITY"
+                :protocol="PROTOCOLS.aeternity"
               />
             </div>
           </div>
@@ -171,7 +171,7 @@ import { IonPage, IonContent } from '@ionic/vue';
 import type { IPermission } from '@/types';
 import {
   PERMISSION_DEFAULTS,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import { useBalances, useCurrencies } from '@/composables';
 import { usePermissions } from '@/composables/permissions';
@@ -214,7 +214,7 @@ export default defineComponent({
     const selectedAsset = computed(() => ({
       contractId: AE_CONTRACT_ID,
       symbol: AE_SYMBOL,
-      currentPrice: getCurrentCurrencyRate(PROTOCOL_AETERNITY),
+      currentPrice: getCurrentCurrencyRate(PROTOCOLS.aeternity),
     }));
 
     const permissionHostValidation = computed(() => !permission.value.host?.includes('localhost'));
@@ -264,7 +264,7 @@ export default defineComponent({
     }, { deep: true });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       ROUTE_PERMISSIONS_SETTINGS,
       DeleteIcon,
       editView,

--- a/src/popup/pages/Popups/Connect.vue
+++ b/src/popup/pages/Popups/Connect.vue
@@ -67,7 +67,7 @@ import {
   PERMISSION_DEFAULTS,
   POPUP_CONNECT_ADDRESS_PERMISSION,
   POPUP_CONNECT_TRANSACTIONS_PERMISSION,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import { useAccounts, usePopupProps } from '@/composables';
 import { usePermissions } from '@/composables/permissions';
@@ -98,7 +98,7 @@ export default defineComponent({
     const { popupProps, sender, setPopupProps } = usePopupProps();
     const { permissions, addPermission } = usePermissions();
 
-    const activeAccount = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const activeAccount = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
 
     const permission = computed(() => {
       const host = popupProps.value?.app?.host;

--- a/src/popup/pages/Popups/MessageSign.vue
+++ b/src/popup/pages/Popups/MessageSign.vue
@@ -48,7 +48,7 @@
 
 <script lang="ts">
 import { defineComponent, onUnmounted } from 'vue';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { RejectedByUserError } from '@/lib/errors';
 import { useAccounts, usePopupProps } from '@/composables';
 
@@ -70,7 +70,7 @@ export default defineComponent({
     const { getLastActiveProtocolAccount } = useAccounts();
     const { popupProps, sender, setPopupProps } = usePopupProps();
 
-    const activeAccount = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    const activeAccount = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
 
     function cancel() {
       popupProps.value?.reject(new RejectedByUserError());

--- a/src/popup/pages/Retip.vue
+++ b/src/popup/pages/Retip.vue
@@ -4,7 +4,7 @@
       <div class="retip">
         <BalanceInfo
           :balance="numericBalance"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
         />
 
         <DetailsItem
@@ -41,7 +41,7 @@
             class="amount-input"
             readonly
             :message="errorMessage"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           />
         </Field>
 
@@ -104,7 +104,7 @@ import {
 } from '@/composables';
 import { AE_COIN_PRECISION, AE_CONTRACT_ID } from '@/protocols/aeternity/config';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useAeTippingBackend, useAeTippingUrls } from '@/protocols/aeternity/composables';
 
 import InputAmount from '../components/InputAmount.vue';
@@ -162,7 +162,7 @@ export default defineComponent({
         ? (formModel.value.selectedAsset as IToken).decimals
         : AE_COIN_PRECISION;
       const amount = toShiftedBigNumber(+(formModel.value.amount || 0), precision).toNumber();
-      const account = getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!;
+      const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity)!;
       setLoaderVisible(true);
       try {
         const { tippingV1, tippingV2 } = await getTippingContracts();
@@ -233,7 +233,7 @@ export default defineComponent({
     onMounted(async () => {
       setLoaderVisible(true);
       formModel.value.selectedAsset = ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_AETERNITY)
+        .getAdapter(PROTOCOLS.aeternity)
         .getDefaultCoin(marketData.value!, +balance.value);
 
       if (!tipId) throw new Error('"id" param is missing');
@@ -248,7 +248,7 @@ export default defineComponent({
     });
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       tip,
       formModel,
       urlStatus,

--- a/src/popup/plugins/veeValidate.ts
+++ b/src/popup/plugins/veeValidate.ts
@@ -13,7 +13,7 @@ import {
 import {
   NETWORK_NAME_MAINNET,
   NETWORK_NAME_TESTNET,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import { isNotFoundError, isUrlValid } from '@/utils';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -184,7 +184,7 @@ export default () => {
   defineRule(
     'ae_min_tip_amount',
     (value: string) => {
-      const aeMinTipAmount = 0.01 / (currencyRates.value?.[PROTOCOL_AETERNITY].usd || 1);
+      const aeMinTipAmount = 0.01 / (currencyRates.value?.[PROTOCOLS.aeternity].usd || 1);
       return BigNumber(value).isGreaterThan(aeMinTipAmount) || tg('pages.tipPage.minAmountError');
     },
   );

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -15,7 +15,7 @@ import {
   POPUP_TYPE_RAW_SIGN,
   POPUP_TYPE_ACCOUNT_LIST,
   RUNNING_IN_POPUP,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   UNFINISHED_FEATURES,
 } from '@/constants';
 import { watchUntilTruthy } from '@/utils';
@@ -86,8 +86,8 @@ router.beforeEach(async (to, from, next) => {
     }
 
     // In-app browser only works with AE accounts
-    if (activeAccount.value.protocol !== PROTOCOL_AETERNITY) {
-      const lastActiveAeAccount = getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+    if (activeAccount.value.protocol !== PROTOCOLS.aeternity) {
+      const lastActiveAeAccount = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
       setActiveAccountByGlobalIdx(lastActiveAeAccount?.globalIdx);
       next({ name: ROUTE_APPS_BROWSER });
       return;

--- a/src/protocols/aeternity/components/TransferReview.vue
+++ b/src/protocols/aeternity/components/TransferReview.vue
@@ -8,7 +8,7 @@
     :loading="loading"
     :avatar-name="isAddressChain ? transferData.address : undefined"
     :show-fiat="isSelectedAssetAex9"
-    :protocol="PROTOCOL_AETERNITY"
+    :protocol="PROTOCOLS.aeternity"
     class="transfer-review"
   >
     <template #subheader>
@@ -18,7 +18,7 @@
       >
         <AccountItem
           :address="activeMultisigAccount.gaAccountId"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
         />
       </div>
     </template>
@@ -46,7 +46,7 @@
           <TokenAmount
             :amount="PROPOSE_TRANSACTION_FEE"
             :symbol="AE_SYMBOL"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             hide-fiat
             high-precision
             data-cy="multisig-review-fee"
@@ -65,7 +65,7 @@
           <TokenAmount
             :amount="+transferData.total"
             :symbol="AE_SYMBOL"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
             high-precision
             data-cy="review-total"
           />
@@ -104,7 +104,7 @@ import {
 } from '@/composables';
 import { AE_SYMBOL, AE_CONTRACT_ID, TX_FUNCTIONS } from '@/protocols/aeternity/config';
 import { ROUTE_MULTISIG_DETAILS_PROPOSAL_DETAILS } from '@/popup/router/routeNames';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { aeToAettos } from '@/protocols/aeternity/helpers';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 
@@ -192,7 +192,7 @@ export default defineComponent({
             { waitMined: false },
           );
         } else {
-          const aeternityAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_AETERNITY);
+          const aeternityAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.aeternity);
           actionResult = await aeternityAdapter.spend(amount, recipient, {
             payload: props.transferData.payload,
           });
@@ -379,7 +379,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       isSelectedAssetAex9,
       activeMultisigAccount,
       AE_SYMBOL,

--- a/src/protocols/aeternity/components/TransferReviewTip.vue
+++ b/src/protocols/aeternity/components/TransferReviewTip.vue
@@ -34,7 +34,7 @@
         <AddressTruncated
           show-explorer-link
           :address="activeAccount.address"
-          :protocol="PROTOCOL_AETERNITY"
+          :protocol="PROTOCOLS.aeternity"
         />
       </div>
     </div>
@@ -45,7 +45,7 @@
         :amount="+transferData.amount"
         :symbol="tokenSymbol"
         :hide-fiat="isAex9"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         data-cy="review-total"
       />
       <span class="lowercase">{{ $t('pages.send.to') }}</span>
@@ -75,7 +75,7 @@
 </template>
 
 <script>
-import { AGGREGATOR_URL, PROTOCOL_AETERNITY } from '@/constants';
+import { AGGREGATOR_URL, PROTOCOLS } from '@/constants';
 import { AE_CONTRACT_ID } from '@/protocols/aeternity/config';
 import { useAccounts } from '@/composables';
 import { getDefaultAccountLabel } from '@/utils';
@@ -116,7 +116,7 @@ export default {
     return {
       AGGREGATOR_URL,
       AE_CONTRACT_ID,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       note: '',
       noteMaxLength: 280,
     };

--- a/src/protocols/aeternity/components/TransferSendForm.vue
+++ b/src/protocols/aeternity/components/TransferSendForm.vue
@@ -4,7 +4,7 @@
     :transfer-data="transferData"
     :fee="+fee.toFixed()"
     :fee-symbol="AE_SYMBOL"
-    :protocol="PROTOCOL_AETERNITY"
+    :protocol="PROTOCOLS.aeternity"
     class="transfer-send-form"
   >
     <template
@@ -50,7 +50,7 @@
           <template #value>
             <AccountItem
               :address="multisigVaultAddress"
-              :protocol="PROTOCOL_AETERNITY"
+              :protocol="PROTOCOLS.aeternity"
             />
           </template>
         </DetailsItem>
@@ -62,14 +62,14 @@
         v-model.trim="formModel.address"
         :errors="errors"
         :is-tip-url="isTipUrl"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         :placeholder="(isUrlTippingEnabled)
           ? $t('modals.send.recipientPlaceholderUrl')
           : $t('modals.send.recipientPlaceholder')"
         :validation-rules="{
           aens_name_registered_or_address_or_url: isUrlTippingEnabled,
           aens_name_registered_or_address: !isUrlTippingEnabled,
-          address_not_same_as: (isMultisig) ? [multisigVaultAddress, PROTOCOL_AETERNITY] : false,
+          address_not_same_as: (isMultisig) ? [multisigVaultAddress, PROTOCOLS.aeternity] : false,
           token_to_an_address: [!isAe],
         }"
         @openQrModal="openScanQrModal"
@@ -83,7 +83,7 @@
         :errors="errors"
         :selected-asset="formModel.selectedAsset"
         :readonly="isMultisig"
-        :protocol="PROTOCOL_AETERNITY"
+        :protocol="PROTOCOLS.aeternity"
         :validation-rules="{
           ...+balance.minus(fee) > 0 && !isMultisig ? { max_value: max } : {},
           ...isMultisig ? { enough_ae_signer: fee.toString() } : { enough_coin: fee.toString() },
@@ -168,7 +168,7 @@ import type {
 } from '@/types';
 import {
   MODAL_PAYLOAD_FORM,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
 } from '@/constants';
 import {
   checkIfSuperheroCallbackUrl,
@@ -261,7 +261,7 @@ export default defineComponent({
 
     function getSelectedAssetValue(tokenContractId?: string, selectedAsset?: IAsset) {
       const aeCoin = ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_AETERNITY)
+        .getAdapter(PROTOCOLS.aeternity)
         .getDefaultCoin(marketData.value!, +balance.value);
 
       if (tokenContractId) {
@@ -290,7 +290,7 @@ export default defineComponent({
     } = useTransferSendForm({
       transferData: props.transferData,
       getSelectedAssetValue,
-      protocol: PROTOCOL_AETERNITY,
+      protocol: PROTOCOLS.aeternity,
     });
 
     const { max, fee } = useMaxAmount({ formModel });
@@ -419,7 +419,7 @@ export default defineComponent({
     return {
       INFO_BOX_TYPES,
       AE_SYMBOL,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       isAe,
       hasMultisigTokenWarning,
       multisigVaultAddress,

--- a/src/protocols/aeternity/composables/aeNames.ts
+++ b/src/protocols/aeternity/composables/aeNames.ts
@@ -21,7 +21,7 @@ import {
 import { Encoded, NAME_TTL } from '@aeternity/aepp-sdk';
 import {
   AUTO_EXTEND_NAME_BLOCKS_INTERVAL,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   STORAGE_KEYS,
 } from '@/constants';
 import Logger from '@/lib/logger';
@@ -122,7 +122,7 @@ export function useAeNames() {
 
     if (
       isLocalAccountAddress(address)
-      || getLastActiveProtocolAccount(PROTOCOL_AETERNITY)?.address === address
+      || getLastActiveProtocolAccount(PROTOCOLS.aeternity)?.address === address
     ) {
       return computed(() => defaultNamesRegistry.value[nodeNetworkId.value!]?.[address] || '');
     }
@@ -172,7 +172,7 @@ export function useAeNames() {
   }
 
   function fetchPendingNameClaimTransactions(address: Encoded.AccountAddress) {
-    const aeternityAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_AETERNITY);
+    const aeternityAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.aeternity);
     return aeternityAdapter.fetchPendingTransactions(address)
       .then(
         (transactions: ITransaction[]) => (transactions)

--- a/src/protocols/aeternity/helpers/index.ts
+++ b/src/protocols/aeternity/helpers/index.ts
@@ -27,7 +27,7 @@ import type {
   TxFunctionRaw,
   TxType,
 } from '@/types';
-import { HASH_REGEX, PROTOCOL_AETERNITY, TX_DIRECTION } from '@/constants';
+import { HASH_REGEX, PROTOCOLS, TX_DIRECTION } from '@/constants';
 import {
   compareCaseInsensitive,
   errorHasValidationKey,
@@ -139,7 +139,7 @@ export function convertMultisigAccountToAccount(
 ): Partial<IAccount> {
   return {
     address: multisigAccount.gaAccountId,
-    protocol: PROTOCOL_AETERNITY,
+    protocol: PROTOCOLS.aeternity,
     idx: 0,
     globalIdx: 0,
   };

--- a/src/protocols/aeternity/libs/AeAccountHdWallet.ts
+++ b/src/protocols/aeternity/libs/AeAccountHdWallet.ts
@@ -15,7 +15,7 @@ import { Ref } from 'vue';
 import type { ITx } from '@/types';
 import { useAccounts } from '@/composables/accounts';
 import { usePermissions } from '@/composables/permissions';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 
 interface InternalOptions {
   fromAccount?: Encoded.AccountAddress;
@@ -29,7 +29,7 @@ export class AeAccountHdWallet extends AccountBase {
   constructor(nodeNetworkId: Ref<string | undefined>) {
     super();
     const { getLastActiveProtocolAccount } = useAccounts();
-    this.address = getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!.address;
+    this.address = getLastActiveProtocolAccount(PROTOCOLS.aeternity)!.address;
     this.nodeNetworkId = nodeNetworkId;
   }
 
@@ -96,9 +96,9 @@ export class AeAccountHdWallet extends AccountBase {
     const { getLastActiveProtocolAccount, getAccountByAddress } = useAccounts();
     const account = (options?.fromAccount)
       ? getAccountByAddress(options.fromAccount)
-      : getLastActiveProtocolAccount(PROTOCOL_AETERNITY);
+      : getLastActiveProtocolAccount(PROTOCOLS.aeternity);
 
-    if (account && account.secretKey && account.protocol === PROTOCOL_AETERNITY) {
+    if (account && account.secretKey && account.protocol === PROTOCOLS.aeternity) {
       return sign(data, account.secretKey);
     }
 

--- a/src/protocols/aeternity/libs/AeSdkSuperhero.ts
+++ b/src/protocols/aeternity/libs/AeSdkSuperhero.ts
@@ -10,7 +10,7 @@ import {
 import { Accounts } from '@aeternity/aepp-sdk/es/aepp-wallet-communication/rpc/types';
 import { Ref } from 'vue';
 import type { IWalletInfo } from '@/types';
-import { PROTOCOL_AETERNITY } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { useAccounts } from '@/composables/accounts';
 import { AeAccountHdWallet } from './AeAccountHdWallet';
 
@@ -39,7 +39,7 @@ export class AeSdkSuperhero extends AeSdkWallet {
   getAccounts() {
     const accounts: Accounts = { connected: {}, current: {} };
     const { getLastActiveProtocolAccount } = useAccounts();
-    const account = getLastActiveProtocolAccount(PROTOCOL_AETERNITY)!;
+    const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity)!;
 
     if (account) {
       accounts.current[account.address] = {};

--- a/src/protocols/aeternity/libs/AeternityAdapter.ts
+++ b/src/protocols/aeternity/libs/AeternityAdapter.ts
@@ -19,7 +19,7 @@ import type {
   ITransaction,
   Protocol,
 } from '@/types';
-import { PROTOCOL_AETERNITY, TXS_PER_PAGE } from '@/constants';
+import { PROTOCOLS, TXS_PER_PAGE } from '@/constants';
 import { useAeSdk } from '@/composables/aeSdk';
 import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
 import { tg } from '@/popup/plugins/i18n';
@@ -49,7 +49,7 @@ interface IAmountDecimalPlaces {
 }
 
 export class AeternityAdapter extends BaseProtocolAdapter {
-  protocol = PROTOCOL_AETERNITY as Protocol;
+  protocol = PROTOCOLS.aeternity as Protocol;
 
   protocolName = AE_PROTOCOL_NAME;
 
@@ -114,7 +114,7 @@ export class AeternityAdapter extends BaseProtocolAdapter {
     convertedBalance?: number,
   ): ICoin {
     return {
-      ...(marketData?.[PROTOCOL_AETERNITY] || {}),
+      ...(marketData?.[PROTOCOLS.aeternity] || {}),
       contractId: AE_CONTRACT_ID,
       // TODO - check usages why sometimes it's a bignumber
       decimals: AE_COIN_PRECISION,

--- a/src/protocols/aeternity/views/AccountCreateModal.vue
+++ b/src/protocols/aeternity/views/AccountCreateModal.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { MODAL_MULTISIG_VAULT_CREATE, PROTOCOL_AETERNITY } from '@/constants';
+import { MODAL_MULTISIG_VAULT_CREATE, PROTOCOLS } from '@/constants';
 import { useAccounts, useConnection, useModals } from '@/composables';
 
 import BtnSubheader from '@/popup/components/buttons/BtnSubheader.vue';
@@ -70,9 +70,9 @@ export default defineComponent({
     async function createPlainAccount() {
       const idx = addRawAccount({
         isRestored: false,
-        protocol: PROTOCOL_AETERNITY,
+        protocol: PROTOCOLS.aeternity,
       });
-      setActiveAccountByProtocolAndIdx(PROTOCOL_AETERNITY, idx);
+      setActiveAccountByProtocolAndIdx(PROTOCOLS.aeternity, idx);
       props.resolve();
     }
 

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -19,7 +19,7 @@
             :show-header="!isDexAllowance"
             :hide-amount="isDex || isDexAllowance || isMultisig"
             :hash="hash"
-            :protocol="PROTOCOL_AETERNITY"
+            :protocol="PROTOCOLS.aeternity"
           >
             <template #tokens>
               <TransactionTokens
@@ -137,7 +137,7 @@
                   <TokenAmount
                     :amount="+aettosToAe(gasPrice)"
                     :symbol="AE_SYMBOL"
-                    :protocol="PROTOCOL_AETERNITY"
+                    :protocol="PROTOCOLS.aeternity"
                     hide-fiat
                   />
                 </template>
@@ -177,7 +177,7 @@ import {
   useTransactionTx,
   useUi,
 } from '@/composables';
-import { PROTOCOL_AETERNITY, TX_DIRECTION } from '@/constants';
+import { PROTOCOLS, TX_DIRECTION } from '@/constants';
 import {
   fetchJson,
   handleUnknownError,
@@ -378,7 +378,7 @@ export default defineComponent({
 
     return {
       AE_SYMBOL,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       TX_DIRECTION,
       transaction,
       isSwap,

--- a/src/protocols/aeternity/views/TransferReceiveModal.vue
+++ b/src/protocols/aeternity/views/TransferReceiveModal.vue
@@ -9,14 +9,14 @@
     :account-name="activeAccountName"
     :tokens="availableTokens"
     :disable-asset-selection="isMultisig"
-    :protocol="PROTOCOL_AETERNITY"
+    :protocol="PROTOCOLS.aeternity"
   />
 </template>
 
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 import {
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   PROTOCOL_VIEW_TRANSFER_RECEIVE,
 } from '@/constants';
 import { useAccounts, useFungibleTokens, useMultisigAccounts } from '@/composables';
@@ -45,7 +45,7 @@ export default defineComponent({
     const activeAccountName = props.isMultisig ? undefined : getName(activeAccount.value.address);
 
     return {
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       availableTokens,
       activeAccountAddress,
       activeAccountName,

--- a/src/protocols/aeternity/views/TransferSendModal.vue
+++ b/src/protocols/aeternity/views/TransferSendModal.vue
@@ -1,6 +1,6 @@
 <template>
   <TransferSendBase
-    :protocol="PROTOCOL_AETERNITY"
+    :protocol="PROTOCOLS.aeternity"
     :current-step="currentStep"
     :hide-arrow-send-icon="isMultisig"
     :custom-primary-button-text="customPrimaryButtonText"
@@ -39,7 +39,7 @@ import type {
   TransferSendStepConfigRegistry,
 } from '@/types';
 import {
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   PROTOCOL_VIEW_TRANSFER_SEND,
   TRANSFER_SEND_STEPS,
 } from '@/constants';
@@ -136,7 +136,7 @@ export default defineComponent({
 
     return {
       TRANSFER_SEND_STEPS,
-      PROTOCOL_AETERNITY,
+      PROTOCOLS,
       currentRenderedComponent,
       steps,
       currentStep,

--- a/src/protocols/bitcoin/components/TransferReview.vue
+++ b/src/protocols/bitcoin/components/TransferReview.vue
@@ -4,7 +4,7 @@
     :transfer-data="transferData"
     :loading="loading"
     show-fiat
-    :protocol="PROTOCOL_BITCOIN"
+    :protocol="PROTOCOLS.bitcoin"
     class="transfer-review"
   >
     <template #total>
@@ -17,7 +17,7 @@
             :amount="+transferData.total"
             :symbol="BTC_SYMBOL"
             high-precision
-            :protocol="PROTOCOL_BITCOIN"
+            :protocol="PROTOCOLS.bitcoin"
             data-cy="review-total"
           />
         </template>
@@ -36,7 +36,7 @@ import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAccounts, useModals, useUi } from '@/composables';
 import type { TransferFormModel } from '@/types';
-import { PROTOCOL_BITCOIN } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 
 import TransferReviewBase from '@/popup/components/TransferSend/TransferReviewBase.vue';
@@ -85,7 +85,7 @@ export default defineComponent({
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async function transfer({ amount, recipient, selectedAsset }: any) {
-      const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_BITCOIN);
+      const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.bitcoin);
       try {
         loading.value = true;
         const { hash } = await bitcoinAdapter.spend(BigNumber(amount).toNumber(), recipient, {
@@ -124,7 +124,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_BITCOIN,
+      PROTOCOLS,
       BTC_SYMBOL,
       loading,
       submit,

--- a/src/protocols/bitcoin/components/TransferSendForm.vue
+++ b/src/protocols/bitcoin/components/TransferSendForm.vue
@@ -4,17 +4,17 @@
     :transfer-data="transferData"
     :fee="numericFee"
     :fee-symbol="BTC_SYMBOL"
-    :protocol="PROTOCOL_BITCOIN"
+    :protocol="PROTOCOLS.bitcoin"
     :custom-title="$t('modals.send.sendAsset', { name: BTC_COIN_NAME })"
     class="transfer-send-form"
   >
     <template #recipient>
       <TransferSendRecipient
         v-model.trim="formModel.address"
-        :placeholder="$t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOL_BITCOIN })"
+        :placeholder="$t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOLS.bitcoin })"
         :errors="errors"
-        :protocol="PROTOCOL_BITCOIN"
-        :validation-rules="{ account_address: [PROTOCOL_BITCOIN, activeNetwork.type] }"
+        :protocol="PROTOCOLS.bitcoin"
+        :validation-rules="{ account_address: [PROTOCOLS.bitcoin, activeNetwork.type] }"
         @openQrModal="openScanQrModal"
       />
     </template>
@@ -25,7 +25,7 @@
         :errors="errors"
         :selected-asset="formModel.selectedAsset"
         readonly
-        :protocol="PROTOCOL_BITCOIN"
+        :protocol="PROTOCOLS.bitcoin"
         :validation-rules="{
           ...+balance.minus(fee) > 0
             ? { max_value: max.toString() }
@@ -85,7 +85,7 @@ import {
   useNetworks,
 } from '@/composables';
 import { useTransferSendForm } from '@/composables/transferSendForm';
-import { NETWORK_TYPE_TESTNET, PROTOCOL_BITCOIN } from '@/constants';
+import { NETWORK_TYPE_TESTNET, PROTOCOLS } from '@/constants';
 import {
   executeAndSetInterval,
   fetchJson,
@@ -132,7 +132,7 @@ export default defineComponent({
     'error',
   ],
   setup(props, { emit }) {
-    const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_BITCOIN);
+    const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.bitcoin);
 
     const route = useRoute();
     const { t } = useI18n();
@@ -155,7 +155,7 @@ export default defineComponent({
       updateFormModelValues,
     } = useTransferSendForm({
       transferData: props.transferData,
-      protocol: PROTOCOL_BITCOIN,
+      protocol: PROTOCOLS.bitcoin,
     });
 
     const feeSelectedIndex = ref(1);
@@ -275,7 +275,7 @@ export default defineComponent({
       BTC_SYMBOL,
       BTC_COIN_NAME,
       DUST_AMOUNT,
-      PROTOCOL_BITCOIN,
+      PROTOCOLS,
       NETWORK_TYPE_TESTNET,
       hasMultisigTokenWarning,
       formModel,

--- a/src/protocols/bitcoin/composables/btcNetworkSettings.ts
+++ b/src/protocols/bitcoin/composables/btcNetworkSettings.ts
@@ -3,7 +3,7 @@ import type { NetworkTypeDefault } from '@/types';
 import {
   NETWORK_TYPE_CUSTOM,
   NETWORK_TYPE_TESTNET,
-  PROTOCOL_BITCOIN,
+  PROTOCOLS,
 } from '@/constants';
 import { useNetworks } from '@/composables/networks';
 import { BTC_NETWORK_ADDITIONAL_SETTINGS } from '@/protocols/bitcoin/config';
@@ -12,7 +12,7 @@ export function useBtcNetworkSettings() {
   const { activeNetwork, activeNetworkName } = useNetworks();
 
   const btcActiveNetworkSettings = computed(
-    () => activeNetwork.value.protocols[PROTOCOL_BITCOIN] as any, // TODO - type btc network
+    () => activeNetwork.value.protocols[PROTOCOLS.bitcoin] as any, // TODO - type btc network
   );
 
   const btcActiveNetworkPredefinedSettings = computed(

--- a/src/protocols/bitcoin/helpers/index.ts
+++ b/src/protocols/bitcoin/helpers/index.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import type { ITransaction } from '@/types';
-import { PROTOCOL_BITCOIN } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { BTC_COIN_PRECISION } from '../config';
 
 export function satoshiToBtc(amount: number) {
@@ -29,7 +29,7 @@ export function normalizeTransactionStructure(
   } = transaction;
 
   return {
-    protocol: PROTOCOL_BITCOIN,
+    protocol: PROTOCOLS.bitcoin,
     transactionOwner: transactionOwner as any,
     hash: txid, // TODO: we can go with additional field
     microTime: status.block_time * 1000,

--- a/src/protocols/bitcoin/libs/BitcoinAdapter.ts
+++ b/src/protocols/bitcoin/libs/BitcoinAdapter.ts
@@ -26,7 +26,7 @@ import { useNetworks } from '@/composables/networks';
 import {
   NETWORK_TYPE_MAINNET,
   NETWORK_TYPE_TESTNET,
-  PROTOCOL_BITCOIN,
+  PROTOCOLS,
 } from '@/constants';
 import { tg } from '@/popup/plugins/i18n';
 import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
@@ -49,7 +49,7 @@ import { useBtcNetworkSettings } from '@/protocols/bitcoin/composables/btcNetwor
 import { BitcoinTransactionSigner } from './BitcoinTransactionSigner';
 
 export class BitcoinAdapter extends BaseProtocolAdapter {
-  protocol = PROTOCOL_BITCOIN as Protocol;
+  protocol = PROTOCOLS.bitcoin as Protocol;
 
   protocolName = 'Bitcoin';
 
@@ -111,7 +111,7 @@ export class BitcoinAdapter extends BaseProtocolAdapter {
     convertedBalance?: number,
   ): ICoin {
     return {
-      ...(marketData?.[PROTOCOL_BITCOIN] || {}),
+      ...(marketData?.[PROTOCOLS.bitcoin] || {}),
       contractId: BTC_CONTRACT_ID,
       symbol: BTC_SYMBOL,
       decimals: BTC_COIN_PRECISION,

--- a/src/protocols/bitcoin/views/TransactionDetails.vue
+++ b/src/protocols/bitcoin/views/TransactionDetails.vue
@@ -13,7 +13,7 @@
             :explorer-url="explorerUrl"
             :hash="hash"
             :none-ae-coin="tokens"
-            :protocol="PROTOCOL_BITCOIN"
+            :protocol="PROTOCOLS.bitcoin"
             show-header
           >
             <template #tokens>
@@ -46,7 +46,7 @@ import { IonContent, IonPage } from '@ionic/vue';
 
 import type { ITransaction } from '@/types';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
-import { TX_DIRECTION, PROTOCOL_BITCOIN } from '@/constants';
+import { TX_DIRECTION, PROTOCOLS } from '@/constants';
 import { BTC_SYMBOL } from '@/protocols/bitcoin/config';
 import { getTxAmountTotal } from '@/protocols/bitcoin/helpers';
 import { ROUTE_NOT_FOUND } from '@/popup/router/routeNames';
@@ -76,7 +76,7 @@ export default defineComponent({
 
     const explorerUrl = computed(
       () => ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_BITCOIN)
+        .getAdapter(PROTOCOLS.bitcoin)
         .getExplorer()
         .prepareUrlForHash(transaction.value?.hash),
     );
@@ -109,7 +109,7 @@ export default defineComponent({
 
     onMounted(async () => {
       try {
-        const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_BITCOIN);
+        const bitcoinAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.bitcoin);
         transaction.value = {
           ...await bitcoinAdapter.getTransactionByHash(hash),
           transactionOwner,
@@ -121,7 +121,7 @@ export default defineComponent({
 
     return {
       BTC_SYMBOL,
-      PROTOCOL_BITCOIN,
+      PROTOCOLS,
       direction,
       explorerUrl,
       hash,

--- a/src/protocols/bitcoin/views/TransferReceiveModal.vue
+++ b/src/protocols/bitcoin/views/TransferReceiveModal.vue
@@ -3,7 +3,7 @@
     v-bind="$attrs"
     :heading="$t('modals.receive.title', { name: protocolName })"
     :account-address="activeAccount.address"
-    :protocol="PROTOCOL_BITCOIN"
+    :protocol="PROTOCOLS.bitcoin"
     disable-asset-selection
   />
 </template>
@@ -11,7 +11,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import {
-  PROTOCOL_BITCOIN,
+  PROTOCOLS,
   PROTOCOL_VIEW_TRANSFER_RECEIVE,
 } from '@/constants';
 import { useAccounts } from '@/composables';
@@ -28,9 +28,9 @@ export default defineComponent({
     const { activeAccount } = useAccounts();
 
     return {
-      PROTOCOL_BITCOIN,
+      PROTOCOLS,
       activeAccount,
-      protocolName: ProtocolAdapterFactory.getAdapter(PROTOCOL_BITCOIN).protocolName,
+      protocolName: ProtocolAdapterFactory.getAdapter(PROTOCOLS.bitcoin).protocolName,
     };
   },
 });

--- a/src/protocols/bitcoin/views/TransferSendModal.vue
+++ b/src/protocols/bitcoin/views/TransferSendModal.vue
@@ -1,6 +1,6 @@
 <template>
   <TransferSendBase
-    :protocol="PROTOCOL_BITCOIN"
+    :protocol="PROTOCOLS.bitcoin"
     :current-step="currentStep"
     :sending-disabled="error || !transferData.address || !transferData.amount"
     @close="resolve"
@@ -32,7 +32,7 @@ import type {
   TransferSendStepConfigRegistry,
 } from '@/types';
 import {
-  PROTOCOL_BITCOIN,
+  PROTOCOLS,
   PROTOCOL_VIEW_TRANSFER_SEND,
   TRANSFER_SEND_STEPS,
 } from '@/constants';
@@ -64,7 +64,7 @@ export default defineComponent({
       amount: props.amount,
       payload: props.payload,
       selectedAsset: ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_BITCOIN)
+        .getAdapter(PROTOCOLS.bitcoin)
         .getDefaultCoin(marketData.value!, +balance.value),
     });
 
@@ -96,7 +96,7 @@ export default defineComponent({
 
     return {
       TRANSFER_SEND_STEPS,
-      PROTOCOL_BITCOIN,
+      PROTOCOLS,
       currentRenderedComponent,
       steps,
       currentStep,

--- a/src/protocols/ethereum/components/TransferReview.vue
+++ b/src/protocols/ethereum/components/TransferReview.vue
@@ -3,7 +3,7 @@
     :base-token-symbol="ETH_SYMBOL"
     :transfer-data="transferData"
     :loading="loading"
-    :protocol="PROTOCOL_ETHEREUM"
+    :protocol="PROTOCOLS.ethereum"
     class="transfer-review"
     show-fiat
   >
@@ -16,7 +16,7 @@
           <TokenAmount
             :amount="+transferData.total"
             :symbol="ETH_SYMBOL"
-            :protocol="PROTOCOL_ETHEREUM"
+            :protocol="PROTOCOLS.ethereum"
             data-cy="review-total"
             high-precision
           />
@@ -36,7 +36,7 @@ import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAccounts, useModals, useUi } from '@/composables';
 import type { TransferFormModel } from '@/types';
-import { PROTOCOL_ETHEREUM } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { ETH_SYMBOL } from '@/protocols/ethereum/config';
 
 import TransferReviewBase from '@/popup/components/TransferSend/TransferReviewBase.vue';
@@ -75,14 +75,14 @@ export default defineComponent({
     }
 
     async function transfer({ amount, recipient }: { amount: string; recipient: string }) {
-      const ethereumAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOL_ETHEREUM);
+      const ethereumAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.ethereum);
       try {
         loading.value = true;
         const { hash } = await ethereumAdapter.spend(
           Number(amount),
           recipient,
           {
-            fromAccount: getLastActiveProtocolAccount(PROTOCOL_ETHEREUM),
+            fromAccount: getLastActiveProtocolAccount(PROTOCOLS.ethereum),
             maxPriorityFeePerGas: props.transferData.maxPriorityFeePerGas,
             maxFeePerGas: props.transferData.maxFeePerGas,
           },
@@ -117,7 +117,7 @@ export default defineComponent({
     }
 
     return {
-      PROTOCOL_ETHEREUM,
+      PROTOCOLS,
       ETH_SYMBOL,
       loading,
       submit,

--- a/src/protocols/ethereum/components/TransferSendForm.vue
+++ b/src/protocols/ethereum/components/TransferSendForm.vue
@@ -4,7 +4,7 @@
     :transfer-data="transferData"
     :fee="numericFee"
     :fee-symbol="ETH_SYMBOL"
-    :protocol="PROTOCOL_ETHEREUM"
+    :protocol="PROTOCOLS.ethereum"
     :custom-title="$t('modals.send.sendAsset', { name: ETH_COIN_NAME })"
     class="transfer-send-form"
   >
@@ -13,8 +13,8 @@
         v-model.trim="formModel.address"
         :placeholder="recipientPlaceholderText"
         :errors="errors"
-        :protocol="PROTOCOL_ETHEREUM"
-        :validation-rules="{ account_address: [PROTOCOL_ETHEREUM] }"
+        :protocol="PROTOCOLS.ethereum"
+        :validation-rules="{ account_address: [PROTOCOLS.ethereum] }"
         @openQrModal="openScanQrModal"
       />
     </template>
@@ -24,7 +24,7 @@
         v-model="formModel.amount"
         :errors="errors"
         :selected-asset="formModel.selectedAsset"
-        :protocol="PROTOCOL_ETHEREUM"
+        :protocol="PROTOCOLS.ethereum"
         :validation-rules="{
           ...+balance.minus(fee) > 0
             ? { max_value: max.toString() }
@@ -81,7 +81,7 @@ import {
 } from '@/composables';
 import { useEthBaseFee } from '@/protocols/ethereum/composables/ethBaseFee';
 import { useTransferSendForm } from '@/composables/transferSendForm';
-import { NETWORK_TYPE_TESTNET, PROTOCOL_ETHEREUM } from '@/constants';
+import { NETWORK_TYPE_TESTNET, PROTOCOLS } from '@/constants';
 import {
   executeAndSetInterval,
 } from '@/utils';
@@ -139,7 +139,7 @@ export default defineComponent({
       updateFormModelValues,
     } = useTransferSendForm({
       transferData: props.transferData,
-      protocol: PROTOCOL_ETHEREUM,
+      protocol: PROTOCOLS.ethereum,
     });
 
     const isTestnet = activeNetwork.value.type === NETWORK_TYPE_TESTNET;
@@ -194,7 +194,7 @@ export default defineComponent({
     const numericFee = computed(() => +fee.value.toFixed());
     const max = computed(() => balance.value.minus(fee.value));
 
-    const recipientPlaceholderText = `${t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOL_ETHEREUM })} ${t('modals.send.recipientPlaceholderENS')}`;
+    const recipientPlaceholderText = `${t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOLS.ethereum })} ${t('modals.send.recipientPlaceholderENS')}`;
 
     function emitCurrentFormModelState() {
       const inputPayload: TransferFormModel = {
@@ -271,7 +271,7 @@ export default defineComponent({
     return {
       ETH_COIN_NAME,
       ETH_SYMBOL,
-      PROTOCOL_ETHEREUM,
+      PROTOCOLS,
       NETWORK_TYPE_TESTNET,
       formModel,
       activeNetwork,

--- a/src/protocols/ethereum/composables/ethNetworkSettings.ts
+++ b/src/protocols/ethereum/composables/ethNetworkSettings.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 import type { NetworkTypeDefault } from '@/types';
-import { NETWORK_TYPE_CUSTOM, NETWORK_TYPE_TESTNET, PROTOCOL_ETHEREUM } from '@/constants';
+import { NETWORK_TYPE_CUSTOM, NETWORK_TYPE_TESTNET, PROTOCOLS } from '@/constants';
 import { useNetworks } from '@/composables/networks';
 import { ETH_NETWORK_ADDITIONAL_SETTINGS } from '@/protocols/ethereum/config';
 
@@ -8,7 +8,7 @@ export function useEthNetworkSettings() {
   const { activeNetwork, activeNetworkName } = useNetworks();
 
   const ethActiveNetworkSettings = computed(
-    () => activeNetwork.value.protocols[PROTOCOL_ETHEREUM] as any, // TODO - type ethereum network
+    () => activeNetwork.value.protocols[PROTOCOLS.ethereum] as any, // TODO - type ethereum network
   );
 
   const ethActiveNetworkPredefinedSettings = computed(

--- a/src/protocols/ethereum/helpers/index.ts
+++ b/src/protocols/ethereum/helpers/index.ts
@@ -1,7 +1,7 @@
 import { fromWei, toChecksumAddress, toWei } from 'web3-utils';
 import BigNumber from 'bignumber.js';
 import { ITransaction } from '@/types';
-import { PROTOCOL_ETHEREUM } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { ETH_CONTRACT_ID, ETH_SAFE_CONFIRMATION_COUNT } from '../config';
 
 /**
@@ -33,7 +33,7 @@ export function normalizeTransactionStructure(
   const pending = parseInt(confirmations, 10) <= ETH_SAFE_CONFIRMATION_COUNT;
   const microTime = timeStamp * 1000;
   return {
-    protocol: PROTOCOL_ETHEREUM,
+    protocol: PROTOCOLS.ethereum,
     transactionOwner: transactionOwner as any,
     hash,
     microTime,

--- a/src/protocols/ethereum/libs/EthereumAdapter.ts
+++ b/src/protocols/ethereum/libs/EthereumAdapter.ts
@@ -29,7 +29,7 @@ import type {
   IFetchTransactionResult,
   IAccount,
 } from '@/types';
-import { PROTOCOL_ETHEREUM } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { getLastNotEmptyAccountIndex } from '@/utils';
 import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
 import { tg } from '@/popup/plugins/i18n';
@@ -49,7 +49,7 @@ import { EtherscanExplorer } from './EtherscanExplorer';
 import { EtherscanService } from './EtherscanService';
 
 export class EthereumAdapter extends BaseProtocolAdapter {
-  override protocol = PROTOCOL_ETHEREUM as Protocol;
+  override protocol = PROTOCOLS.ethereum as Protocol;
 
   override protocolName = ETH_PROTOCOL_NAME;
 
@@ -117,7 +117,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
     convertedBalance?: number,
   ): ICoin {
     return {
-      ...(marketData?.[PROTOCOL_ETHEREUM] || {}),
+      ...(marketData?.[PROTOCOLS.ethereum] || {}),
       contractId: ETH_CONTRACT_ID,
       symbol: ETH_SYMBOL,
       decimals: ETH_COIN_PRECISION,

--- a/src/protocols/ethereum/views/TransferReceiveModal.vue
+++ b/src/protocols/ethereum/views/TransferReceiveModal.vue
@@ -2,7 +2,7 @@
   <TransferReceiveBase
     :heading="$t('modals.receive.title', { name: protocolName })"
     :account-address="activeAccount.address"
-    :protocol="PROTOCOL_ETHEREUM"
+    :protocol="protocol"
     disable-asset-selection
   />
 </template>
@@ -10,7 +10,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import {
-  PROTOCOL_ETHEREUM,
+  PROTOCOLS,
   PROTOCOL_VIEW_TRANSFER_RECEIVE,
 } from '@/constants';
 import { useAccounts } from '@/composables';
@@ -27,9 +27,9 @@ export default defineComponent({
     const { activeAccount } = useAccounts();
 
     return {
-      PROTOCOL_ETHEREUM,
+      protocol: PROTOCOLS.ethereum,
       activeAccount,
-      protocolName: ProtocolAdapterFactory.getAdapter(PROTOCOL_ETHEREUM).protocolName,
+      protocolName: ProtocolAdapterFactory.getAdapter(PROTOCOLS.ethereum).protocolName,
     };
   },
 });

--- a/src/protocols/ethereum/views/TransferSendModal.vue
+++ b/src/protocols/ethereum/views/TransferSendModal.vue
@@ -31,8 +31,8 @@ import type {
   TransferSendStepConfigRegistry,
 } from '@/types';
 import {
-  PROTOCOL_ETHEREUM,
   PROTOCOL_VIEW_TRANSFER_SEND,
+  PROTOCOLS,
   TRANSFER_SEND_STEPS,
 } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -63,7 +63,7 @@ export default defineComponent({
       amount: props.amount,
       payload: props.payload,
       selectedAsset: ProtocolAdapterFactory
-        .getAdapter(PROTOCOL_ETHEREUM)
+        .getAdapter(PROTOCOLS.ethereum)
         .getDefaultCoin(marketData.value!, +balance.value),
     });
 
@@ -95,7 +95,6 @@ export default defineComponent({
 
     return {
       TRANSFER_SEND_STEPS,
-      PROTOCOL_ETHEREUM,
       currentRenderedComponent,
       steps,
       currentStep,

--- a/src/protocols/registerAdapters.ts
+++ b/src/protocols/registerAdapters.ts
@@ -1,5 +1,5 @@
 import type { Class, Protocol } from '@/types';
-import { PROTOCOL_AETERNITY, PROTOCOL_BITCOIN, PROTOCOL_ETHEREUM } from '@/constants';
+import { PROTOCOLS } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import { AeternityAdapter } from '@/protocols/aeternity/libs/AeternityAdapter';
 import { BitcoinAdapter } from '@/protocols/bitcoin/libs/BitcoinAdapter';
@@ -7,9 +7,9 @@ import { EthereumAdapter } from '@/protocols/ethereum/libs/EthereumAdapter';
 import { BaseProtocolAdapter } from './BaseProtocolAdapter';
 
 const protocolAdapters: Record<Protocol, Class<BaseProtocolAdapter>> = {
-  [PROTOCOL_AETERNITY]: AeternityAdapter,
-  [PROTOCOL_BITCOIN]: BitcoinAdapter,
-  [PROTOCOL_ETHEREUM]: EthereumAdapter,
+  [PROTOCOLS.aeternity]: AeternityAdapter,
+  [PROTOCOLS.bitcoin]: BitcoinAdapter,
+  [PROTOCOLS.ethereum]: EthereumAdapter,
 };
 
 Object.entries(protocolAdapters).forEach(([protocol, adapter]) => {

--- a/src/types/protocols.ts
+++ b/src/types/protocols.ts
@@ -2,11 +2,12 @@ import {
   PROTOCOLS,
   DISTINCT_PROTOCOL_VIEWS,
 } from '@/constants';
+import type { ObjectValues } from '.';
 
 /**
  * Blockchain protocol slug name
  */
-export type Protocol = typeof PROTOCOLS[number];
+export type Protocol = ObjectValues<typeof PROTOCOLS>;
 
 /**
  * List of views (pages and modals) that are required by all of the protocols.

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -8,7 +8,7 @@ import {
 } from '../../../src/utils';
 import {
   NETWORK_NAME_TESTNET,
-  PROTOCOL_AETERNITY,
+  PROTOCOLS,
   STORAGE_KEYS,
   TRANSACTIONS_LOCAL_STORAGE_KEY,
 } from '../../../src/constants';
@@ -99,7 +99,7 @@ Cypress.Commands.add('login', (options = {}, route, isMockingExternalRequests = 
       [prepareStorageKey([STORAGE_KEYS.mnemonic])]: STUB_ACCOUNT.mnemonic,
       [prepareStorageKey([STORAGE_KEYS.accountsRaw])]: [{
         idx: 0,
-        protocol: PROTOCOL_AETERNITY,
+        protocol: PROTOCOLS.aeternity,
         isRestored: true,
         type: 'hd-wallet',
       }],

--- a/tests/unit/input-amount.spec.js
+++ b/tests/unit/input-amount.spec.js
@@ -3,7 +3,7 @@ import { config, mount } from '@vue/test-utils';
 import { defineRule } from 'vee-validate';
 import InputAmount from '../../src/popup/components/InputAmount.vue';
 import { AE_SYMBOL } from '../../src/protocols/aeternity/config';
-import { PROTOCOL_AETERNITY } from '../../src/constants';
+import { PROTOCOLS } from '../../src/constants';
 
 const maxBalance = 10000;
 
@@ -15,7 +15,7 @@ config.global = {
 
 describe('InputAmount', () => {
   it('should render', async () => {
-    const wrapper = mount(InputAmount, { props: { protocol: PROTOCOL_AETERNITY } });
+    const wrapper = mount(InputAmount, { props: { protocol: PROTOCOLS.aeternity } });
     expect(wrapper.classes()).toContain('input-amount');
   });
 
@@ -70,7 +70,7 @@ describe('InputAmount', () => {
     const wrapper = mount(InputAmount, {
       props: {
         modelValue: test.value,
-        protocol: PROTOCOL_AETERNITY,
+        protocol: PROTOCOLS.aeternity,
         ...test.props,
       },
     });


### PR DESCRIPTION
I find it sad that we are using TypeScript yet most of our files are red because our `protocol` props are not (and cannot be) typed correctly with our current setup. This is because we are using an array of constsants `PROTOCOLS`. I think it very much makes sense to use a `Protocols` enum in this case as it simplifies things and makes them more straightforward.