### PR TITLE
fix: qr scanner on safari mobile

### DIFF
--- a/src/popup/components/Modals/QrCodeReader.vue
+++ b/src/popup/components/Modals/QrCodeReader.vue
@@ -307,6 +307,11 @@ export default defineComponent({
 
     .video {
       height: var(--camera-size);
+
+      @include mixins.mobile {
+        height: unset;
+        width: var(--camera-size);
+      }
     }
 
     .video-loader {


### PR DESCRIPTION
This is related to the issue #2576 but is not fixing it.
This PR improves scanning on mobile devices with Safari so I suggest to merge it independently