### PR TITLE
fix: owned names should only be updated for current network

### DIFF
--- a/src/popup/pages/Names/NamesList.vue
+++ b/src/popup/pages/Names/NamesList.vue
@@ -25,8 +25,8 @@
 </template>
 
 <script lang="ts">
-import { IonPage, IonContent, onIonViewWillLeave } from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
+import { IonPage, IonContent } from '@ionic/vue';
+import { computed, defineComponent, onUnmounted } from 'vue';
 import { executeAndSetInterval } from '@/utils';
 import { useAccounts, useUi } from '@/composables';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
@@ -60,7 +60,7 @@ export default defineComponent({
       }
     }, POLLING_INTERVAL);
 
-    onIonViewWillLeave(() => {
+    onUnmounted(() => {
       clearInterval(id);
     });
 


### PR DESCRIPTION
closes #2599 

`onIonViewWillLeave` was only being called when user switched from `My names` to other sub-tabs `Auctions` & `Register name`.
When user closed the `account-details` page it was not being called, leaving an unterminated interval.

`onUnmount` will be called when user closes the `account-details` page, which means that while user is on that page, names will update every 10 seconds. But when he leaves this page names will stop updating.