### PR TITLE
fix: transaction list is displaying partly

### DIFF
--- a/src/popup/pages/AccountDetailsMultisig.vue
+++ b/src/popup/pages/AccountDetailsMultisig.vue
@@ -4,6 +4,7 @@
       <AccountDetailsBase
         v-if="activeMultisigAccount"
         without-default-buttons
+        :ionic-lifecycle-status="ionicLifecycleStatus"
       >
         <template #account-info>
           <AccountInfo
@@ -42,7 +43,8 @@
 
 <script lang="ts">
 import { IonContent, IonPage } from '@ionic/vue';
-import { computed, defineComponent } from 'vue';
+import { PropType, computed, defineComponent } from 'vue';
+import { IonicLifecycleStatus } from '@/types';
 import { PROTOCOL_AETERNITY, UNFINISHED_FEATURES } from '@/constants';
 import { useMultisigAccounts } from '@/composables';
 import { buildSimplexLink, convertMultisigAccountToAccount } from '@/protocols/aeternity/helpers';
@@ -68,6 +70,9 @@ export default defineComponent({
     AccountDetailsBase,
     IonPage,
     IonContent,
+  },
+  props: {
+    ionicLifecycleStatus: { type: String as PropType<IonicLifecycleStatus>, default: null },
   },
   setup() {
     const { activeMultisigAccount } = useMultisigAccounts();

--- a/src/protocols/aeternity/views/AccountDetails.vue
+++ b/src/protocols/aeternity/views/AccountDetails.vue
@@ -1,7 +1,10 @@
 <template>
   <IonPage>
     <IonContent class="account-ion-content">
-      <AccountDetailsBase class="account-details">
+      <AccountDetailsBase
+        v-if="isPageActive"
+        class="account-details"
+      >
         <template #buttons>
           <BtnBox
             v-if="isNodeMainnet && UNFINISHED_FEATURES"
@@ -33,8 +36,15 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from 'vue';
+import {
+  PropType,
+  computed,
+  defineComponent,
+  ref,
+  watch,
+} from 'vue';
 import { IonContent, IonPage } from '@ionic/vue';
+import { IonicLifecycleStatus } from '@/types';
 import {
   IS_MOBILE_APP,
   IS_IOS,
@@ -68,13 +78,26 @@ export default defineComponent({
     IonPage,
     IonContent,
   },
-  setup() {
+  props: {
+    ionicLifecycleStatus: { type: String as PropType<IonicLifecycleStatus>, default: null },
+  },
+  setup(props) {
+    const isPageActive = ref(false);
+
     const { isOnline } = useConnection();
     const { isNodeMainnet, isNodeTestnet } = useAeSdk();
     const { activeAccount } = useAccounts();
 
     const activeAccountFaucetUrl = computed(() => buildAeFaucetUrl(activeAccount.value.address));
     const activeAccountSimplexLink = computed(() => buildSimplexLink(activeAccount.value.address));
+
+    watch(() => props.ionicLifecycleStatus, (status) => {
+      if (status === 'didEnter') {
+        isPageActive.value = true;
+      } else if (status === 'didLeave') {
+        isPageActive.value = false;
+      }
+    });
 
     return {
       UNFINISHED_FEATURES,
@@ -92,6 +115,7 @@ export default defineComponent({
       activeAccount,
       activeAccountSimplexLink,
       activeAccountFaucetUrl,
+      isPageActive,
     };
   },
 });

--- a/src/protocols/bitcoin/views/AccountDetails.vue
+++ b/src/protocols/bitcoin/views/AccountDetails.vue
@@ -1,14 +1,23 @@
 <template>
   <IonPage>
     <IonContent class="account-ion-content">
-      <AccountDetailsBase class="account-details" />
+      <AccountDetailsBase
+        v-if="isPageActive"
+        class="account-details"
+      />
     </IonContent>
   </IonPage>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import {
+  PropType,
+  defineComponent,
+  ref,
+  watch,
+} from 'vue';
 import { IonContent, IonPage } from '@ionic/vue';
+import { IonicLifecycleStatus } from '@/types';
 import { PROTOCOL_VIEW_ACCOUNT_DETAILS } from '@/constants';
 import AccountDetailsBase from '@/popup/components/AccountDetailsBase.vue';
 
@@ -18,6 +27,24 @@ export default defineComponent({
     AccountDetailsBase,
     IonPage,
     IonContent,
+  },
+  props: {
+    ionicLifecycleStatus: { type: String as PropType<IonicLifecycleStatus>, default: null },
+  },
+  setup(props) {
+    const isPageActive = ref(false);
+
+    watch(() => props.ionicLifecycleStatus, (status) => {
+      if (status === 'didEnter') {
+        isPageActive.value = true;
+      } else if (status === 'didLeave') {
+        isPageActive.value = false;
+      }
+    });
+
+    return {
+      isPageActive,
+    };
   },
 });
 </script>


### PR DESCRIPTION
closes #2572 
closes #2563

As much as I hate using this `ionicLifecycleStatus` prop, it is the best way to achieve what we're trying to do. Which is to calculate the tabs-height after the page transition has played. `onIonViewDidEnter` fires at exactly that moment but isn't directly available to the `AccountDetailsBase` component thus we pass it as a prop.
Using the timeout didn't always work correctly because depending on the user's machine the animation can take longer or even not play at all (e.g. animations are disabled on FF or user visits the page directly) 