### PR TITLE
refactor: unify icon sizes

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -382,6 +382,19 @@ export const ALLOWED_ICON_STATUSES = [
   'warning',
 ] as const;
 
+/**
+ * Pixel size is defined in css variables in global.scss
+ */
+export const ICON_SIZES = {
+  xs: 'xs', // 12px
+  sm: 'sm', // 16px
+  rg: 'rg', // 18px
+  md: 'md', // 20px
+  lg: 'lg', // 24px
+  xl: 'xl', // 28px
+  xxl: 'xxl', // 30px
+} as const;
+
 export const TRANSACTIONS_LOCAL_STORAGE_KEY = 'transactions';
 export const TRANSFER_SEND_DATA_LOCAL_STORAGE_KEY = 'transfer-send-data';
 

--- a/src/popup/components/AccountItem.vue
+++ b/src/popup/components/AccountItem.vue
@@ -17,7 +17,7 @@
       <ProtocolIcon
         v-if="protocol"
         :protocol="protocol"
-        icon-size="sm"
+        icon-size="xs"
         class="protocol-icon"
       />
     </div>

--- a/src/popup/components/IconWrapper.vue
+++ b/src/popup/components/IconWrapper.vue
@@ -22,14 +22,15 @@
 <script lang="ts">
 import { Component, PropType, defineComponent } from 'vue';
 import ProtocolIcon from '@/popup/components/ProtocolIcon.vue';
+import { ICON_SIZES } from '@/constants';
 
-const ALLOWED_ICON_SIZES = ['rg', 'lg'] as const;
+const ALLOWED_ICON_SIZES = [ICON_SIZES.lg, ICON_SIZES.xl] as const;
 
 type IconSize = typeof ALLOWED_ICON_SIZES[number];
 
 export const iconSizeProp = {
   type: String as PropType<IconSize>,
-  default: 'rg',
+  default: ICON_SIZES.lg,
   validator: (val: IconSize) => ALLOWED_ICON_SIZES.includes(val),
 };
 
@@ -57,7 +58,7 @@ export default defineComponent({
 
 .icon-wrapper {
   --wrapper-size: 36px;
-  --icon-size: 24px; // rg
+  --icon-size: var(--icon-size-lg);
 
   display: inline-flex;
   align-items: center;
@@ -84,8 +85,8 @@ export default defineComponent({
   }
 
   &.icon-size {
-    &-lg {
-      --icon-size: 28px;
+    &-xl {
+      --icon-size: var(--icon-size-xl);
     }
   }
 }

--- a/src/popup/components/Modals/NetworkSwitcherModal.vue
+++ b/src/popup/components/Modals/NetworkSwitcherModal.vue
@@ -19,7 +19,7 @@
       "
       :icon="(network.type === NETWORK_TYPE_MAINNET) ? GlobeIcon : GlobeCogIcon"
       :selected="network.name === activeNetwork.name"
-      icon-size="lg"
+      icon-size="xl"
       @click="switchNetworkAndClose(network.name)"
     />
 

--- a/src/popup/components/ProtocolIcon.vue
+++ b/src/popup/components/ProtocolIcon.vue
@@ -14,14 +14,14 @@ import {
   defineComponent,
   PropType,
 } from 'vue';
-import { PROTOCOLS } from '@/constants';
+import { ICON_SIZES, PROTOCOLS } from '@/constants';
 import type { Protocol } from '@/types';
 import AeternityIcon from '@/icons/coin/aeternity.svg?vue-component';
 import AeternityLogo from '@/icons/logo/aeternity.svg?vue-component';
 import BitcoinIcon from '@/icons/coin/bitcoin.svg?vue-component';
 import EthereumIcon from '@/icons/coin/ethereum.svg?vue-component';
 
-const SIZES = ['sm', 'rg'] as const;
+const SIZES = [ICON_SIZES.xs, ICON_SIZES.md, ICON_SIZES.lg] as const;
 
 export type AllowedProtocolIconSize = typeof SIZES[number];
 
@@ -33,7 +33,7 @@ export default defineComponent({
     },
     iconSize: {
       type: String as PropType<AllowedProtocolIconSize>,
-      default: 'rg',
+      default: ICON_SIZES.md,
       validator: (val: AllowedProtocolIconSize) => SIZES.includes(val),
     },
     isLogoIcon: { type: Boolean, default: false },
@@ -59,14 +59,18 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .protocol-icon {
-  --icon-size: 20px;
+  --icon-size: var(--icon-size-md);
 
   display: inline-block;
   width: var(--icon-size);
   height: var(--icon-size);
 
-  &.sm {
-    --icon-size: 12px;
+  &.xs {
+    --icon-size: var(--icon-size-xs);
+  }
+
+  &.lg {
+    --icon-size: var(--icon-size-lg);
   }
 }
 </style>

--- a/src/popup/components/Tokens.vue
+++ b/src/popup/components/Tokens.vue
@@ -47,7 +47,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue';
 import type { ITokenResolved, Protocol } from '@/types';
-import { ASSET_TYPES, PROTOCOLS } from '@/constants';
+import { ASSET_TYPES, ICON_SIZES, PROTOCOLS } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import {
   isCoin,
@@ -56,7 +56,7 @@ import {
 import { AE_AVATAR_URL } from '@/protocols/aeternity/config';
 import ProtocolIcon from './ProtocolIcon.vue';
 
-const SIZES = ['rg', 'md', 'lg', 'xl'] as const;
+const SIZES = [ICON_SIZES.sm, ICON_SIZES.rg, ICON_SIZES.lg, ICON_SIZES.xxl] as const;
 
 export type AllowedTokenIconSize = typeof SIZES[number];
 
@@ -77,7 +77,7 @@ export default defineComponent({
     protocol: { type: String as PropType<Protocol>, required: true, default: PROTOCOLS.aeternity },
     iconSize: {
       type: String as PropType<AllowedTokenIconSize>,
-      default: 'rg',
+      default: ICON_SIZES.sm,
       validator: (val: AllowedTokenIconSize) => SIZES.includes(val),
     },
     vertical: Boolean,
@@ -148,7 +148,7 @@ export default defineComponent({
 @use '../../styles/typography';
 
 .tokens {
-  --icon-size: 16px;
+  --icon-size: var(--icon-size-sm);
 
   @extend %face-sans-16-semi-bold;
 
@@ -198,16 +198,16 @@ export default defineComponent({
     vertical-align: middle;
   }
 
-  &.md {
-    --icon-size: 18px;
+  &.rg {
+    --icon-size: var(--icon-size-rg);
   }
 
   &.lg {
-    --icon-size: 24px;
+    --icon-size: var(--icon-size-lg);
   }
 
-  &.xl {
-    --icon-size: 30px;
+  &.xxl {
+    --icon-size: var(--icon-size-xxl);
   }
 
   &.vertical {

--- a/src/popup/components/TransactionListItem.vue
+++ b/src/popup/components/TransactionListItem.vue
@@ -10,7 +10,7 @@
         :ext-tokens="tokens"
         :error="isErrorTransaction"
         :protocol="transactionProtocol"
-        icon-size="md"
+        icon-size="rg"
       />
       <div class="footer">
         <div

--- a/src/popup/components/TransactionTokenRows.vue
+++ b/src/popup/components/TransactionTokenRows.vue
@@ -56,7 +56,7 @@ export default defineComponent({
   props: {
     transaction: { type: Object as PropType<ITransaction | undefined>, default: null },
     extTokens: { type: Array as PropType<ITokenResolved[] | undefined>, default: null },
-    iconSize: { type: String as PropType<AllowedTokenIconSize>, default: 'rg' },
+    iconSize: { type: String as PropType<AllowedTokenIconSize>, default: 'sm' },
     direction: { type: String, default: '' },
     protocol: { type: String as PropType<Protocol>, required: true },
     error: Boolean,

--- a/src/popup/components/buttons/BtnMain.vue
+++ b/src/popup/components/buttons/BtnMain.vue
@@ -93,7 +93,7 @@ export default defineComponent({
     gap: 4px;
 
     .btn-main-icon {
-      --icon-size: 20px;
+      --icon-size: var(--icon-size-md);
 
       flex-shrink: 0;
       width: var(--icon-size);
@@ -101,7 +101,7 @@ export default defineComponent({
       color: inherit;
 
       &.lg {
-        --icon-size: 24px;
+        --icon-size: var(--icon-size-lg);
       }
     }
   }

--- a/src/popup/pages/MultisigProposalDetails.vue
+++ b/src/popup/pages/MultisigProposalDetails.vue
@@ -14,7 +14,7 @@
               v-if="multisigTx"
               :transaction="{ tx: multisigTx }"
               :protocol="PROTOCOLS.aeternity"
-              icon-size="md"
+              icon-size="rg"
             />
           </div>
           <div class="content">

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -27,7 +27,7 @@
                 :error="isErrorTransaction"
                 :reversed="isPool"
                 :protocol="PROTOCOLS.aeternity"
-                icon-size="md"
+                icon-size="rg"
                 multiple-rows
               />
             </template>

--- a/src/protocols/bitcoin/views/TransactionDetails.vue
+++ b/src/protocols/bitcoin/views/TransactionDetails.vue
@@ -22,7 +22,7 @@
                 :transaction="transaction"
                 :direction="direction"
                 :protocol="PROTOCOLS.bitcoin"
-                icon-size="md"
+                icon-size="rg"
                 multiple-rows
               />
             </template>

--- a/src/protocols/ethereum/views/TransactionDetails.vue
+++ b/src/protocols/ethereum/views/TransactionDetails.vue
@@ -20,7 +20,7 @@
                 :ext-tokens="tokens"
                 :direction="direction"
                 :protocol="PROTOCOLS.ethereum"
-                icon-size="md"
+                icon-size="rg"
                 multiple-rows
               />
             </template>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -19,6 +19,15 @@
   &::-webkit-scrollbar {
     display: none;
   }
+
+  // Icon sizes used with the ICON_SIZES constant
+  --icon-size-xs: 12px;
+  --icon-size-sm: 16px;
+  --icon-size-rg: 18px;
+  --icon-size-md: 20px;
+  --icon-size-lg: 24px;
+  --icon-size-xl: 28px;
+  --icon-size-xxl: 30px;
 }
 
 html.is-extension {

--- a/tests/unit/__snapshots__/snapshot.spec.js.snap
+++ b/tests/unit/__snapshots__/snapshot.spec.js.snap
@@ -220,7 +220,7 @@ exports[`Pages Index 1`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -228,7 +228,7 @@ exports[`Pages Index 1`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"
@@ -257,7 +257,7 @@ exports[`Pages Index 1`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -265,7 +265,7 @@ exports[`Pages Index 1`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"
@@ -369,7 +369,7 @@ exports[`Pages Index 2`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -377,7 +377,7 @@ exports[`Pages Index 2`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"
@@ -406,7 +406,7 @@ exports[`Pages Index 2`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -414,7 +414,7 @@ exports[`Pages Index 2`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"
@@ -518,7 +518,7 @@ exports[`Pages Index 3`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -526,7 +526,7 @@ exports[`Pages Index 3`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"
@@ -555,7 +555,7 @@ exports[`Pages Index 3`] = `
             extend=""
             header="locale-specific-text"
             icon="[object Object]"
-            iconsize="rg"
+            iconsize="lg"
             subheader="locale-specific-text"
           >
             
@@ -563,7 +563,7 @@ exports[`Pages Index 3`] = `
               class="box"
             >
               <div
-                class="icon-wrapper icon-size-rg is-boxed"
+                class="icon-wrapper icon-size-lg is-boxed"
               >
                 <svg
                   class="icon-wrapper-icon"


### PR DESCRIPTION
closes #2578 

_Based on `eth-support` because there were some changes with icons but could be rebased on develop as well if needed._ 
I think having a global standard for icon sizes will help cross-component compatibility (e.g. `ProtocolIcon.vue` inside `Tokens.vue`)
One shortcoming of this approach is that some components do not have `rg` as the default size (which semantically makes sense) but I think that the clarity of the global standard is more important