### PR TITLE
fix: seed-phrase verification alert alignment

### DIFF
--- a/src/popup/components/SeedPhraseNotification.vue
+++ b/src/popup/components/SeedPhraseNotification.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="['seed-phrase-notification', { error: hasError }]">
+  <div
+    :class="['seed-phrase-notification', { error: hasError }]"
+    :style="{ bottom: `${positionBottom}px`, minHeight: `${phraserElHeight}px` }"
+  >
     <div class="icon-wrapper">
       <AlertIcon v-if="hasError" />
       <CheckCircleIcon v-else />
@@ -13,7 +16,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from 'vue';
+import {
+  defineComponent,
+  computed,
+  onMounted,
+  ref,
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 import CheckCircleIcon from '../../icons/check-circle.svg?vue-component';
 import AlertIcon from '../../icons/alert.svg?vue-component';
@@ -25,16 +33,31 @@ export default defineComponent({
   },
   props: {
     hasError: Boolean,
+    phraserEl: { type: HTMLElement, default: null },
   },
   setup(props) {
     const { t } = useI18n();
+
+    const positionBottom = ref(90);
+    const phraserElHeight = ref(176);
 
     const notificationMessage = computed(() => props.hasError
       ? t('pages.seed-phrase-settings.seed-phrase-incorrect')
       : t('pages.seed-phrase-settings.seed-phrase-correct'));
 
+    onMounted(() => {
+      if (props.phraserEl) {
+        phraserElHeight.value = props.phraserEl.getBoundingClientRect().height;
+        const { bottom } = props.phraserEl.getBoundingClientRect();
+        const ionicWrapperBottom = document.querySelector('#app-wrapper')?.getBoundingClientRect()?.bottom;
+        positionBottom.value = Math.floor(ionicWrapperBottom! - bottom - 2); // 2px is border width
+      }
+    });
+
     return {
       notificationMessage,
+      positionBottom,
+      phraserElHeight,
     };
   },
 });
@@ -45,12 +68,10 @@ export default defineComponent({
 @use '../../styles/typography';
 
 .seed-phrase-notification {
-  min-height: 176px;
   border: 2px solid variables.$color-success-dark;
   border-radius: variables.$border-radius-card;
   background: rgba(variables.$color-black, 0.85);
   position: absolute;
-  bottom: 90px;
   width: calc(100% - (2 * var(--screen-padding-x)));
   display: flex;
   flex-direction: column;

--- a/src/popup/pages/SeedPhraseVerifySettings.vue
+++ b/src/popup/pages/SeedPhraseVerifySettings.vue
@@ -31,7 +31,10 @@
             />
           </div>
 
-          <div class="phraser bright">
+          <div
+            ref="phraserLightEl"
+            class="phraser bright"
+          >
             <template v-if="!selectedWordIds.length">
               <SeedPhraseBadge
                 v-for="(word, index) in examplePhrase"
@@ -63,6 +66,7 @@
           <SeedPhraseNotification
             v-if="showNotification"
             :has-error="hasError"
+            :phraser-el="phraserLightEl"
           />
         </FixedScreenFooter>
       </div>
@@ -98,6 +102,8 @@ export default defineComponent({
     IonContent,
   },
   setup() {
+    const phraserLightEl = ref<HTMLElement | undefined>(undefined);
+
     const router = useRouter();
     const { t } = useI18n();
 
@@ -125,7 +131,7 @@ export default defineComponent({
 
       setTimeout(() => {
         showNotification.value = false;
-        router.push({ name: ROUTE_ACCOUNT });
+        router.replace({ name: ROUTE_ACCOUNT });
       }, 3000);
     }
 
@@ -136,6 +142,7 @@ export default defineComponent({
     }
 
     return {
+      phraserLightEl,
       selectedWordIds,
       showNotification,
       hasError,
@@ -168,7 +175,7 @@ export default defineComponent({
 
   .phraser {
     padding: 0;
-    margin: 18px -4px 0 0; // -4px to compensate margin-right on badge
+    margin: 18px 0 0 0;
 
     &.bright {
       background: rgba(variables.$color-white, 0.15);


### PR DESCRIPTION
closes #2626 

Size of the `phraser` element can change if words in seed-phrase are more & bigger. With this change no matter how the big the element is the notification element will always match it pixel perfect