### PR TITLE
Feat/implement back to top button

### DIFF
--- a/src/popup/components/AccountSelector.vue
+++ b/src/popup/components/AccountSelector.vue
@@ -43,7 +43,7 @@
         show-explorer-link
         show-protocol-icon
         :address="modelValue.toString()"
-        :protocol="selectedAccount?.protocol"
+        :protocol="selectedAccount?.protocol!"
         class="address-truncated"
       />
     </div>

--- a/src/popup/components/BackToTop.vue
+++ b/src/popup/components/BackToTop.vue
@@ -1,52 +1,74 @@
 <template>
-  <BtnPlain
-    v-if="isVisible"
+  <div
+    ref="el"
     class="back-to-top"
-    @click="scrollTop"
+    :class="{ sticky }"
   >
-    <Chevron class="chevron" />
-  </BtnPlain>
+    <transition name="fade-transition">
+      <div
+        v-if="isVisible"
+        class="back-to-top-btn-container"
+      >
+        <BtnPlain
+          class="back-to-top-btn"
+          @click="scrollTop"
+        >
+          <Chevron class="chevron" />
+        </BtnPlain>
+      </div>
+    </transition>
+  </div>
 </template>
 
-<script>
+<script lang="ts">
+import {
+  onBeforeUnmount,
+  onMounted,
+  defineComponent,
+  ref,
+} from 'vue';
 import BtnPlain from './buttons/BtnPlain.vue';
 import Chevron from '../../icons/chevron.svg?vue-component';
 
-export default {
+export default defineComponent({
   components: {
     BtnPlain,
     Chevron,
   },
-  data() {
-    return {
-      isVisible: false,
-    };
+  props: {
+    sticky: Boolean,
   },
-  mounted() {
-    if (this.$el?.parentNode) {
-      this.$el.parentNode.addEventListener('scroll', this.handleVisibility);
+  setup() {
+    const el = ref<HTMLElement>();
+    const isVisible = ref(false);
+
+    function handleVisibility() {
+      if (!el.value?.parentNode) return;
+      isVisible.value = (el.value?.parentNode as HTMLElement)?.scrollTop > 800;
     }
-  },
-  beforeUnmount() {
-    if (this.$el?.parentNode) {
-      this.$el.parentNode.removeEventListener('scroll', this.handleVisibility);
-    }
-  },
-  methods: {
-    handleVisibility() {
-      const parent = this.$el?.parentNode;
-      if (!parent) return;
-      this.isVisible = parent.scrollTop > 0;
-    },
-    scrollTop() {
-      const parent = this.$el.parentNode;
-      parent.scrollTo({
+
+    function scrollTop() {
+      (el.value?.parentNode as HTMLElement)?.scrollTo({
         top: 0,
         behavior: 'smooth',
       });
-    },
+    }
+
+    onMounted(() => {
+      el.value?.parentNode?.addEventListener('scroll', handleVisibility);
+    });
+
+    onBeforeUnmount(() => {
+      el.value?.parentNode?.removeEventListener('scroll', handleVisibility);
+    });
+
+    return {
+      el,
+      isVisible,
+      scrollTop,
+    };
   },
-};
+});
 </script>
 
 <style lang="scss" scoped>
@@ -54,25 +76,61 @@ export default {
 @use '../../styles/mixins';
 
 .back-to-top {
-  @include mixins.flex(center, center);
-
   width: 100%;
   height: 40px;
-  background: rgba(variables.$color-white, 0.1);
 
-  &:hover {
-    background: rgba(variables.$color-white, 0.08);
+  &-btn-container {
+    @include mixins.flex(flex-end, center);
+
+    pointer-events: none;
+    position: fixed;
+    z-index: variables.$z-index-header;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding: 12px 4px 4px 0;
+    background: variables.$color-bg-4;
+    background:
+      linear-gradient(
+        180deg,
+        rgba(variables.$color-bg-4, 0) 5%,
+        rgba(variables.$color-bg-4, 0.8) 60%,
+        rgba(variables.$color-bg-4, 0.9) 100%
+      );
+  }
+
+  &-btn {
+    @include mixins.flex(center, center);
+
+    pointer-events: all;
+    height: 40px;
+    width: 41px;
+    border-radius: 10px;
+    background-color: variables.$color-dialog;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover {
+      background: rgba(#272727, 0.8);
+    }
+
+    &:active {
+      background: rgba(#222, 0.8);
+    }
 
     .chevron {
-      opacity: 0.75;
+      width: 22px;
+      height: 22px;
+      transform: rotate(-90deg);
     }
   }
 
-  .chevron {
-    width: 22px;
-    height: 22px;
-    transform: rotate(-90deg);
-    opacity: 0.5;
+  &.sticky {
+    position: sticky;
+    bottom: 0;
+
+    .back-to-top-btn-container {
+      position: absolute;
+    }
   }
 }
 </style>

--- a/src/popup/components/Modal.vue
+++ b/src/popup/components/Modal.vue
@@ -59,6 +59,8 @@
           <slot />
         </div>
 
+        <BackToTop sticky />
+
         <FixedScreenFooter
           v-if="$slots.footer"
           v-bind="$attrs"
@@ -86,11 +88,13 @@ import { BackButtonEvent } from '@ionic/vue';
 import { IS_FIREFOX, IS_EXTENSION } from '@/constants';
 import BtnClose from './buttons/BtnClose.vue';
 import FixedScreenFooter from './FixedScreenFooter.vue';
+import BackToTop from './BackToTop.vue';
 
 export default defineComponent({
   components: {
     FixedScreenFooter,
     BtnClose,
+    BackToTop,
   },
   props: {
     show: Boolean,

--- a/src/popup/components/TransactionList.vue
+++ b/src/popup/components/TransactionList.vue
@@ -38,6 +38,7 @@
         :text="$t('modals.accountDetails.transactionsNotAvailable')"
       />
     </div>
+    <BackToTop />
   </IonContent>
 </template>
 
@@ -88,6 +89,7 @@ import MessageOffline from '@/popup/components/MessageOffline.vue';
 import TransactionListItem from './TransactionListItem.vue';
 import AnimatedSpinner from '../../icons/animated-spinner.svg?skip-optimize';
 import InfiniteScroll from './InfiniteScroll.vue';
+import BackToTop from './BackToTop.vue';
 
 export default defineComponent({
   components: {
@@ -96,6 +98,7 @@ export default defineComponent({
     InfiniteScroll,
     MessageOffline,
     IonContent,
+    BackToTop,
   },
   props: {
     fetchRecentTransactions: { type: Function, required: true },

--- a/src/popup/pages/AccountDetailsMultisigTokens.vue
+++ b/src/popup/pages/AccountDetailsMultisigTokens.vue
@@ -7,6 +7,7 @@
           is-multisig
         />
       </div>
+      <BackToTop />
     </IonContent>
   </IonPage>
 </template>
@@ -17,12 +18,14 @@ import { defineComponent } from 'vue';
 import { useTransactionAndTokenFilter } from '@/composables';
 
 import AssetList from '../components/Assets/AssetList.vue';
+import BackToTop from '../components/BackToTop.vue';
 
 export default defineComponent({
   components: {
     AssetList,
     IonPage,
     IonContent,
+    BackToTop,
   },
   props: {
     showFilters: Boolean,

--- a/src/popup/pages/PrivacyPolicy.vue
+++ b/src/popup/pages/PrivacyPolicy.vue
@@ -353,6 +353,7 @@
           </li>
         </ol>
       </div>
+      <BackToTop />
     </IonContent>
   </IonPage>
 </template>
@@ -367,10 +368,12 @@ import {
   APP_LINK_IOS,
 } from '@/constants';
 import LinkButton from '@/popup/components/LinkButton.vue';
+import BackToTop from '@/popup/components/BackToTop.vue';
 
 export default {
   components: {
     LinkButton,
+    BackToTop,
     IonContent,
     IonPage,
   },

--- a/src/popup/pages/TermsOfService.vue
+++ b/src/popup/pages/TermsOfService.vue
@@ -932,6 +932,7 @@
           </div>
         </AccordionItem>
       </div>
+      <BackToTop />
     </IonContent>
   </IonPage>
 </template>
@@ -950,6 +951,7 @@ import {
 } from '@/constants';
 import AccordionItem from '../components/AccordionItem.vue';
 import LinkButton from '../components/LinkButton.vue';
+import BackToTop from '../components/BackToTop.vue';
 
 export default defineComponent({
   components: {
@@ -957,6 +959,7 @@ export default defineComponent({
     LinkButton,
     IonPage,
     IonContent,
+    BackToTop,
   },
   setup() {
     return {

--- a/src/protocols/aeternity/views/AccountDetailsTokens.vue
+++ b/src/protocols/aeternity/views/AccountDetailsTokens.vue
@@ -17,6 +17,7 @@
           :text="$t('modals.accountDetails.assetsNotAvailable')"
         />
       </div>
+      <BackToTop v-if="isOnline" />
     </IonContent>
   </IonPage>
 </template>
@@ -38,6 +39,7 @@ import { useConnection, useTransactionAndTokenFilter, useScrollConfig } from '@/
 
 import AssetList from '@/popup/components/Assets/AssetList.vue';
 import MessageOffline from '@/popup/components/MessageOffline.vue';
+import BackToTop from '@/popup/components/BackToTop.vue';
 
 export default defineComponent({
   components: {
@@ -45,6 +47,7 @@ export default defineComponent({
     MessageOffline,
     IonPage,
     IonContent,
+    BackToTop,
   },
   props: {
     showFilters: Boolean,

--- a/src/protocols/ethereum/views/AccountDetailsTokens.vue
+++ b/src/protocols/ethereum/views/AccountDetailsTokens.vue
@@ -18,6 +18,7 @@
           :text="$t('modals.accountDetails.assetsNotAvailable')"
         />
       </div>
+      <BackToTop v-if="isOnline" />
     </IonContent>
   </IonPage>
 </template>
@@ -34,6 +35,7 @@ import { useConnection, useTransactionAndTokenFilter } from '@/composables';
 
 import AssetList from '@/popup/components/Assets/AssetList.vue';
 import MessageOffline from '@/popup/components/MessageOffline.vue';
+import BackToTop from '@/popup/components/BackToTop.vue';
 
 export default defineComponent({
   components: {
@@ -41,6 +43,7 @@ export default defineComponent({
     MessageOffline,
     IonPage,
     IonContent,
+    BackToTop,
   },
   props: {
     showFilters: Boolean,

--- a/tests/unit/__snapshots__/snapshot.spec.js.snap
+++ b/tests/unit/__snapshots__/snapshot.spec.js.snap
@@ -1513,6 +1513,18 @@ exports[`Pages PrivacyPolicy 1`] = `
         </li>
       </ol>
     </div>
+    <div
+      class="back-to-top"
+    >
+      <transition-stub
+        appear="false"
+        css="true"
+        name="fade-transition"
+        persisted="false"
+      >
+        <!--v-if-->
+      </transition-stub>
+    </div>
   </ion-content>
 </div>
 `;
@@ -1999,6 +2011,18 @@ exports[`Pages TermsOfService 1`] = `
             <!--v-if-->
           </transition-stub>
         </div>
+      </div>
+      <div
+        class="back-to-top"
+      >
+        <transition-stub
+          appear="false"
+          css="true"
+          name="fade-transition"
+          persisted="false"
+        >
+          <!--v-if-->
+        </transition-stub>
       </div>
     </ion-content>
   </div>


### PR DESCRIPTION
closes #2662 

Based on `feat/eth-support` in order to apply changes to the ETH asset list component.
Turns out we do not need the `is end reached` variable since we want the `back to top` button to appear even if the user has not reached the end yet.
One small improvement we can do once we have the `is end reached` variable is that we can hide the bottom padding that is added by the `back to top` button and only show it when `is end reached`