### PR TITLE
fix: eth account explorer links

### DIFF
--- a/src/popup/components/AddressTruncated.vue
+++ b/src/popup/components/AddressTruncated.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       () => ProtocolAdapterFactory
         .getAdapter(props.protocol)
         .getExplorer()
-        .prepareUrlForHash(props.address),
+        .prepareUrlForAccount(props.address),
     );
 
     return {

--- a/src/popup/components/TransactionOverview.vue
+++ b/src/popup/components/TransactionOverview.vue
@@ -66,7 +66,10 @@ export default defineComponent({
     const name = ref('');
     const ownershipAccount = ref<IAccountOverview | {}>({});
 
-    const adapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.aeternity);
+    const adapter = ProtocolAdapterFactory.getAdapter(
+      props.transaction.protocol
+      || PROTOCOLS.aeternity,
+    );
     const protocolExplorer = adapter.getExplorer();
 
     const {
@@ -85,7 +88,7 @@ export default defineComponent({
       return {
         address,
         label: t('transaction.overview.accountAddress'),
-        url: protocolExplorer.prepareUrlForHash(address),
+        url: protocolExplorer.prepareUrlForAccount(address),
       };
     }
 
@@ -105,13 +108,13 @@ export default defineComponent({
             sender: {
               address: senderId,
               name: getName(senderId).value,
-              url: protocolExplorer.prepareUrlForHash(senderId),
+              url: protocolExplorer.prepareUrlForAccount(senderId),
               label: t('transaction.overview.accountAddress'),
             },
             recipient: {
               address: recipientId,
               name: name.value || getName(recipientId).value,
-              url: protocolExplorer.prepareUrlForHash(recipientId),
+              url: protocolExplorer.prepareUrlForAccount(recipientId),
               label: t('transaction.overview.accountAddress'),
             },
             title: t('transaction.type.spendTx'),
@@ -176,7 +179,7 @@ export default defineComponent({
             sender: {
               address: innerTx.value.ownerId,
               name: getName(innerTx.value.ownerId).value,
-              url: protocolExplorer.prepareUrlForHash(innerTx.value.ownerId),
+              url: protocolExplorer.prepareUrlForAccount(innerTx.value.ownerId),
               label: t('multisig.multisigVault'),
             },
             recipient: {
@@ -191,13 +194,13 @@ export default defineComponent({
               sender: {
                 address: senderId,
                 name: getName(senderId).value,
-                url: protocolExplorer.prepareUrlForHash(senderId),
+                url: protocolExplorer.prepareUrlForAccount(senderId),
                 label: t('transaction.overview.accountAddress'),
               },
               recipient: {
                 address: recipientId,
                 name: name.value || getName(recipientId).value,
-                url: protocolExplorer.prepareUrlForHash(recipientId),
+                url: protocolExplorer.prepareUrlForAccount(recipientId),
                 label: t('transaction.overview.accountAddress'),
               },
               title: t('transaction.type.spendTx'),

--- a/src/protocols/aeternity/libs/AeScan.ts
+++ b/src/protocols/aeternity/libs/AeScan.ts
@@ -37,7 +37,7 @@ export class AeScan extends ProtocolExplorer {
     return (endpoint) ? `${this.explorerUrl}/${endpoint}/${hash}` : undefined;
   }
 
-  override prepareUrlForAccount(address: string) {
-    return `${this.explorerUrl}/accounts/${address}`;
+  override prepareUrlForAccount(addressOrName: string) {
+    return this.prepareUrlForHash(addressOrName) || `${this.explorerUrl}/accounts/${addressOrName}`;
   }
 }

--- a/src/protocols/ethereum/libs/EtherscanExplorer.ts
+++ b/src/protocols/ethereum/libs/EtherscanExplorer.ts
@@ -9,7 +9,7 @@ export class EtherscanExplorer extends ProtocolExplorer {
   }
 
   override prepareUrlForHash(hash: string) {
-    return `${this.explorerUrl}/address/${hash}`;
+    return `${this.explorerUrl}/tx/${hash}`;
   }
 
   override prepareUrlForAccount(address: string) {


### PR DESCRIPTION
Explorer links were wrong because for Aeternity/AeScan we can determine what endpoint to use and we were using `prepareUrlForHash` everywhere, which doesn't work for Ethereum and Bitcoin
