### PR TITLE
fix: delegate http applinks to https

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="wallet.superhero.com" />
             </intent-filter>


### PR DESCRIPTION
The original issue is probably fixed already as the app links seem to be working fine
This PR just adds support for http links
closes #1980 