### PR TITLE
fix: do not call cordova mnemonic migration on extension

### DIFF
--- a/src/composables/accounts.ts
+++ b/src/composables/accounts.ts
@@ -14,7 +14,8 @@ import {
   PROTOCOL_AETERNITY,
   PROTOCOLS,
   STORAGE_KEYS,
-  RUNNING_IN_TESTS,
+  IS_IOS,
+  IS_MOBILE_APP,
 } from '@/constants';
 import {
   prepareAccountSelectOptions,
@@ -39,11 +40,9 @@ const mnemonic = useStorageRef<string>(
   STORAGE_KEYS.mnemonic,
   {
     backgroundSync: true,
-    migrations: RUNNING_IN_TESTS ? [
+    migrations: [
+      ...((IS_IOS && IS_MOBILE_APP) ? [migrateMnemonicCordovaToIonic] : []),
       migrateMnemonicVuexToComposable,
-    ] : [
-      migrateMnemonicVuexToComposable,
-      migrateMnemonicCordovaToIonic,
     ],
   },
 );


### PR DESCRIPTION
closes #2713 
Even though the actual migration was not being called because of the inner if check, it was still causing issues with the extension