### PR TITLE
fix: redirect to 404 when tx cant be fetched

### DIFF
--- a/src/popup/router/routes.ts
+++ b/src/popup/router/routes.ts
@@ -752,8 +752,8 @@ export const routes: WalletAppRouteConfig[] = [
     },
   },
   {
-    path: '/notifications',
     name: ROUTE_NOTIFICATIONS,
+    path: '/notifications',
     component: Notifications,
     meta: {
       title: 'notifications',
@@ -763,8 +763,19 @@ export const routes: WalletAppRouteConfig[] = [
   },
   {
     name: ROUTE_NOT_FOUND,
-    path: '/:pathMatch(.*)*',
+    path: '/page-not-found',
     component: NotFound,
+    props: true,
+    meta: {
+      ifNotAuth: true,
+      notPersist: true,
+      showHeaderNavigation: true,
+      title: 'notFound',
+    },
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: { name: ROUTE_NOT_FOUND },
     props: true,
     meta: {
       ifNotAuth: true,

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -334,6 +334,7 @@ export default defineComponent({
           rawTransaction = pendingTransactions.find((val) => val.hash === hash);
 
           if (!rawTransaction) {
+            setLoaderVisible(false);
             router.push({ name: ROUTE_NOT_FOUND });
             return;
           }

--- a/src/protocols/bitcoin/views/TransactionDetails.vue
+++ b/src/protocols/bitcoin/views/TransactionDetails.vue
@@ -105,6 +105,7 @@ export default defineComponent({
           transactionOwner,
         };
       } catch (e) {
+        setLoaderVisible(false);
         router.push({ name: ROUTE_NOT_FOUND });
       }
     });

--- a/src/protocols/ethereum/views/TransactionDetails.vue
+++ b/src/protocols/ethereum/views/TransactionDetails.vue
@@ -139,6 +139,7 @@ export default defineComponent({
       try {
         transaction.value = await adapter.fetchTransactionByHash(hash, transactionOwner);
       } catch (e) {
+        setLoaderVisible(false);
         router.push({ name: ROUTE_NOT_FOUND });
       }
     });


### PR DESCRIPTION
fixes:
> 8. After sending ERC-20 tokens Txs I clicked on Tx to see Tx details, but the page hang out and I find these issues in console:

from #2736 

If we reach the API limit and can't fetch details for a tx we're redirected to the 404 page. 
This wasn't working properly because we didn't have a specific 404 page path and were trying to display the 404 page at `/`
Now we redirect unknown pages to `/page-not-found`
Also disables the loader before redirecting