### PR TITLE
fix: do not use useI18n outside the setup function

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -8,7 +8,7 @@ import { WatchSource, watch } from 'vue';
 import { defer, uniqWith } from 'lodash-es';
 import BigNumber from 'bignumber.js';
 import { Share } from '@capacitor/share';
-import { useI18n } from 'vue-i18n';
+import { ComposerTranslation } from 'vue-i18n';
 import { LocationQuery } from 'vue-router';
 import type {
   AssetContractId,
@@ -309,7 +309,7 @@ export function removeDuplicatedTransactions(transactions: ITransaction[]) {
 }
 
 export function secondsToRelativeTime(seconds: number, shortForm?: boolean) {
-  const { t } = useI18n();
+  const t = tg as ComposerTranslation;
   const secondsPerMinute = 60;
   const secondsPerHour = secondsPerMinute * 60;
   const secondsPerDay = secondsPerHour * 24;


### PR DESCRIPTION
fixes 
```
Must be called at the top of a `setup` function
SyntaxError: Must be called at the top of a `setup` function
    at createCompileError (webpack-internal:///./node_modules/@intlify/message-compiler/dist/message-compiler.esm-browser.js:113:19)
    at createI18nError (webpack-internal:///./node_modules/vue-i18n/dist/vue-i18n.mjs:115:82)
    at useI18n (webpack-internal:///./node_modules/vue-i18n/dist/vue-i18n.mjs:2316:15)
    at secondsToRelativeTime (webpack-internal:///./src/utils/common.ts:528:68)
    at blocksToRelativeTime (webpack-internal:///./src/utils/common.ts:234:10)
    at eval (webpack-internal:///./node_modules/babel-loader/lib/index.js!./node_modules/ts-loader/index.js??clonedRuleSet-44.use[1]!./node_modules/vue-loader/dist/index.js??ruleSet[0].use[0]!./src/popup/pages/MultisigProposalDetails.vue?vue&type=script&lang=ts:170:131)
    at ReactiveEffect.eval [as fn] (webpack-internal:///./node_modules/@vue/reactivity/dist/reactivity.esm-bundler.js:1037:13)
    at ReactiveEffect.run (webpack-internal:///./node_modules/@vue/reactivity/dist/reactivity.esm-bundler.js:221:19)
    at get value (webpack-internal:///./node_modules/@vue/reactivity/dist/reactivity.esm-bundler.js:1049:147)
    at triggerComputed (webpack-internal:///./node_modules/@vue/reactivity/dist/reactivity.esm-bundler.js:240:19)

```