### PR TITLE
fix: validate several props and emits correctly

### DIFF
--- a/src/popup/components/AssetIcon.vue
+++ b/src/popup/components/AssetIcon.vue
@@ -26,7 +26,7 @@ import EthereumIcon from '@/icons/coin/ethereum.svg?vue-component';
 import LexonTokenIcon from '@/icons/tokens/ct_xtk8rSz9suPb6D6VLquyfVji25FcnFRDjn3dnn5mmvHsPiESt.svg?vue-component';
 import ChainlinkTokenIcon from '@/icons/tokens/0x779877a7b0d9e8603169ddbd7836e478b4624789.svg?vue-component';
 
-const SIZES = [ICON_SIZES.rg, ICON_SIZES.md, ICON_SIZES.lg] as const;
+const SIZES = [ICON_SIZES.sm, ICON_SIZES.rg, ICON_SIZES.md, ICON_SIZES.lg] as const;
 
 const COIN_ICONS: Record<Protocol, Component> = {
   [PROTOCOLS.aeternity]: AeternityIcon,

--- a/src/popup/components/ProtocolIcon.vue
+++ b/src/popup/components/ProtocolIcon.vue
@@ -20,7 +20,7 @@ import AeternityLogo from '@/icons/logo/aeternity.svg?vue-component';
 import BitcoinIcon from '@/icons/coin/bitcoin.svg?vue-component';
 import EthereumIcon from '@/icons/coin/ethereum.svg?vue-component';
 
-const SIZES = [ICON_SIZES.xs, ICON_SIZES.rg, ICON_SIZES.md, ICON_SIZES.lg] as const;
+const SIZES = [ICON_SIZES.xs, ICON_SIZES.md, ICON_SIZES.lg] as const;
 
 export type AllowedProtocolIconSize = typeof SIZES[number];
 

--- a/src/popup/components/TransferSend/TransferSendAmount.vue
+++ b/src/popup/components/TransferSend/TransferSendAmount.vue
@@ -70,7 +70,7 @@ export default defineComponent({
     withoutMargin: Boolean,
     protocol: { type: String as PropType<Protocol>, required: true },
   },
-  emits: ['update:modelValue', 'assetSelected'],
+  emits: ['update:modelValue', 'asset-selected'],
   setup(props) {
     const amountMessage = computed(() => getMessageByFieldName(props.errors.amount));
 

--- a/src/popup/plugins/veeValidate.ts
+++ b/src/popup/plugins/veeValidate.ts
@@ -113,7 +113,7 @@ defineRule(
   'is_hex_format',
   (value: string) => (
     (
-      value.toString().startsWith('0x')
+      value?.toString()?.startsWith('0x')
       && value.length >= 3
       && parseInt(value.slice(2), 16).toString(16) === value.slice(2).toLowerCase()
     )


### PR DESCRIPTION
fixes emit and prop validation issues
```
logger.ts:50 Invalid prop: custom validator check failed for prop "iconSize". at <AssetIcon>
at <Tokens>

[Vue warn]: Component emitted event "asset-selected" but it is neither declared in the emits option nor as an "onAsset-selected" prop.
```
Also fixes this issue on custom network creation
```
veeValidate.ts:114 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'toString')
```
