### PR TITLE
fix: use correct nonce to dry-run contract calls

### DIFF
--- a/src/composables/maxAmount.ts
+++ b/src/composables/maxAmount.ts
@@ -165,7 +165,7 @@ export function useMaxAmount({ formModel }: MaxAmountOptions) {
       const aeSdk = await getAeSdk();
       try {
         nonce.value = (await aeSdk.api
-          .getAccountByPubkey(getAccount().address))?.nonce;
+          .getAccountNextNonce(getAccount().address)).nextNonce;
       } catch (error: any) {
         if (!error.message.includes('Account not found')) handleUnknownError(error);
       }


### PR DESCRIPTION
This PR is supported by the Æternity Foundation