### PR TITLE
fix: show correct details for pending ethereum transactions

### DIFF
--- a/src/protocols/ethereum/helpers/index.ts
+++ b/src/protocols/ethereum/helpers/index.ts
@@ -36,7 +36,7 @@ export function normalizeWeb3EthTransactionStructure(
     protocol: PROTOCOLS.ethereum,
     hash: hash as any,
     microTime: timestamp ? new Date(Number(timestamp) * 1000).getTime() : undefined,
-    pending: blockNumber === null, // if blockNumber is null, transaction is pending
+    pending: !blockNumber, // if blockNumber is falsy, transaction is pending
     blockHeight: Number(blockNumber),
     tx: {
       amount: Number(fromWei(value || 0, 'ether')),

--- a/src/protocols/ethereum/libs/EthereumAdapter.ts
+++ b/src/protocols/ethereum/libs/EthereumAdapter.ts
@@ -333,7 +333,9 @@ export class EthereumAdapter extends BaseProtocolAdapter {
       return tokenTx;
     }
 
-    const block = await getBlock(web3Eth, transaction?.blockHash, true, DEFAULT_RETURN_FORMAT);
+    const block = transaction?.blockHash
+      ? await getBlock(web3Eth, transaction.blockHash, true, DEFAULT_RETURN_FORMAT)
+      : undefined;
     const normalized = normalizeWeb3EthTransactionStructure(transaction, block, transactionOwner);
     return normalized;
   }


### PR DESCRIPTION
fixed #2789 

Also removes timestamp and block number from pending transactions 
(`getBlock` will return a block even if `blockHash` is missing)