### PR TITLE
feat: allow replace caller in sign transaction

### DIFF
--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -37,6 +37,12 @@
         class="reason"
         data-cy="reason"
       />
+      <span
+        v-if="popupProps?.isSenderReplaced"
+        class="sender-replaced"
+      >
+        {{ $t('modals.confirmTransactionSign.senderReplaced') }}
+      </span>
       <DetailsItem
         v-if="decodedCallData?.functionName"
         :label="$t('modals.confirmTransactionSign.functionName')"
@@ -601,6 +607,13 @@ export default defineComponent({
       word-break: break-all;
       color: variables.$color-warning;
     }
+  }
+
+  .sender-replaced {
+    @extend %face-sans-15-regular;
+
+    color: variables.$color-warning;
+    margin-top: 8px;
   }
 
   .details {

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -297,6 +297,7 @@
       "functionName": "Function name",
       "arguments": "Arguments",
       "superheroChat": "Superhero Chat",
+      "senderReplaced": "Your active wallet account will be the sender for the transaction.",
       "unableToExecute": "This transaction can not be executed.",
       "confirmSigning": "would like you to confirm a transaction."
     },

--- a/src/popup/pages/SignTransaction.vue
+++ b/src/popup/pages/SignTransaction.vue
@@ -86,7 +86,8 @@ export default defineComponent({
           {
             networkId,
             aeppOrigin: callbackOrigin.value?.toString(),
-          },
+            isSenderReplaced: replaceCaller === 'true',
+          } as any,
         );
 
         if (broadcast) {

--- a/src/popup/pages/SignTransaction.vue
+++ b/src/popup/pages/SignTransaction.vue
@@ -8,9 +8,11 @@ import { IonPage } from '@ionic/vue';
 import { defineComponent, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { Encoded } from '@aeternity/aepp-sdk';
+import {
+  buildTx, Encoded, Tag, unpackTx,
+} from '@aeternity/aepp-sdk';
 
-import { DEFAULT_WAITING_HEIGHT } from '@/constants';
+import { DEFAULT_WAITING_HEIGHT, PROTOCOLS } from '@/constants';
 import { RejectedByUserError } from '@/lib/errors';
 import { handleUnknownError } from '@/utils';
 import {
@@ -18,6 +20,7 @@ import {
   useModals,
   useAeSdk,
   useUi,
+  useAccounts,
 } from '@/composables';
 
 export default defineComponent({
@@ -34,11 +37,30 @@ export default defineComponent({
       const { nodeNetworkId, getAeSdk } = useAeSdk();
       const { openDefaultModal } = useModals();
       const { setLoaderVisible } = useUi();
+      const { getLastActiveProtocolAccount } = useAccounts();
+
+      const aeSdk = await getAeSdk();
+      const activeAccountAddress = getLastActiveProtocolAccount(
+        PROTOCOLS.aeternity,
+      )?.address as Encoded.AccountAddress;
+
+      async function replaceCallerTx(tx: Encoded.Transaction, callerId: Encoded.AccountAddress) {
+        const unpackedTx = unpackTx(tx) as ReturnType<typeof unpackTx>
+          & { callerId: Encoded.AccountAddress };
+
+        if (unpackedTx.tag === Tag.ContractCallTx || unpackedTx.tag === Tag.ContractCreateTx) {
+          unpackedTx.callerId = callerId;
+          unpackedTx.nonce = (await aeSdk.api.getAccountByPubkey(callerId)).nonce + 1;
+        }
+
+        return buildTx(unpackedTx);
+      }
 
       try {
         setLoaderVisible(true);
-        const aeSdk = await getAeSdk();
-        const { transaction, networkId, broadcast } = route.query;
+        const {
+          transaction, networkId, broadcast, 'replace-caller': replaceCaller,
+        } = route.query;
 
         if (networkId !== nodeNetworkId.value) {
           await openDefaultModal({
@@ -51,8 +73,16 @@ export default defineComponent({
           return;
         }
 
+        // replacing the caller might be chosen by an aepp if no wallet connection is available
+        // but a transaction should be proposed to the user anyway
+        // e.g. to reduce the number of steps necessary in a deep-link environment,
+        // from two round trips, aepp -> wallet -> aepp, to one
+        const txToSign = replaceCaller === 'true'
+          ? await replaceCallerTx(transaction as Encoded.Transaction, activeAccountAddress)
+          : transaction;
+
         const signedTransaction = await aeSdk.signTransaction(
-          decodeURIComponent(transaction as string) as Encoded.Transaction,
+          decodeURIComponent(txToSign as string) as Encoded.Transaction,
           {
             networkId,
             aeppOrigin: callbackOrigin.value?.toString(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -685,6 +685,7 @@ export interface IPopupData {
 export interface IPopupProps extends IPopupActions, IPopupData {
   show?: boolean; // Decides if the modal window should be open
   fromAccount?: string;
+  isSenderReplaced?: boolean;
 }
 
 export interface IModalProps extends Partial<IPopupProps> {


### PR DESCRIPTION
the idea here is to be able to prepare a transaction externally without knowing who will execute it (i.e. to save an additional step to get account via deeplink callback)