### PR TITLE
perf: use dryAeSdk to collect multisig info

### DIFF
--- a/src/composables/aeSdk.ts
+++ b/src/composables/aeSdk.ts
@@ -107,10 +107,11 @@ export function useAeSdk() {
 
   async function resetNode(oldNetwork: INetwork, newNetwork: INetwork) {
     isAeSdkUpdating.value = true;
+    const nodeInstance = await createNodeInstance(newNetwork.protocols.aeternity.nodeUrl);
     aeSdk.pool.delete(oldNetwork.name);
     aeSdk.addNode(
       newNetwork.name,
-      (await createNodeInstance(newNetwork.protocols.aeternity.nodeUrl))!,
+      nodeInstance!,
       true,
     );
     isAeSdkUpdating.value = false;

--- a/src/composables/multisigAccounts.ts
+++ b/src/composables/multisigAccounts.ts
@@ -74,7 +74,7 @@ export function useMultisigAccounts({
 }: MultisigAccountsOptions = {}) {
   const { onNetworkChange } = useNetworks();
   const { aeActiveNetworkPredefinedSettings } = useAeNetworkSettings();
-  const { nodeNetworkId, getAeSdk } = useAeSdk();
+  const { nodeNetworkId, getAeSdk, getDryAeSdk } = useAeSdk();
   const { aeAccounts } = useAccounts();
 
   const allMultisigAccounts = computed<IMultisigAccount[]>(() => [
@@ -179,7 +179,7 @@ export function useMultisigAccounts({
    * Refresh the list of the multisig accounts.
    */
   async function updateMultisigAccounts() {
-    const aeSdk = await getAeSdk();
+    const dryAeSdk = await getDryAeSdk();
 
     /**
      * Establish the list of multisig accounts used by the regular accounts
@@ -219,7 +219,7 @@ export function useMultisigAccounts({
           ...otherMultisigData
         }): Promise<IMultisigAccount> => {
           try {
-            const contractInstance = await aeSdk.initializeContract({
+            const contractInstance = await dryAeSdk.initializeContract({
               aci: SimpleGAMultiSigAci,
               address: contractId,
             });
@@ -243,7 +243,7 @@ export function useMultisigAccounts({
                 ? { decodedResult: currentAccount.signers }
                 : contractInstance.get_signers(),
               contractInstance.get_consensus_info(),
-              gaAccountId ? aeSdk.getBalance(gaAccountId as Encoded.AccountAddress) : 0,
+              gaAccountId ? dryAeSdk.getBalance(gaAccountId as Encoded.AccountAddress) : 0,
             ]));
 
             const decodedConsensus = consensusResult.decodedResult;


### PR DESCRIPTION
fixing one part of the issue raised here
https://github.com/superhero-com/superhero-wallet/blob/d233c480fcbc0a0ab1ddf79deda42b30d96495c5/src/protocols/aeternity/libs/AeSdkSuperhero.ts#L35
by simply using `dryRunSdk` that doesn't have accounts and will not call our overridden `_resolveAccount` method, every time we are updating multisig vaults info.