### PR TITLE
fix: remove window browser polyfill from ext background

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,12 +1,12 @@
-import '@/lib/initPolyfills';
 import { PopupActionType } from '@/types';
 import { openPopup, removePopup, getPopup } from './bgPopupHandler';
 import { updateDynamicRules } from './redirectRule';
 
-async function setupOffscreenDocument(path: string) {
+(async () => {
   // Check all windows controlled by the service worker to see if one
   // of them is the offscreen document with the given path
-  const offscreenUrl = browser.runtime.getURL(path);
+  const offscreenUrl = browser.runtime.getURL('offscreen.html');
+
   // @ts-expect-error - browser type is not complete
   const existingContexts = await browser.runtime.getContexts({
     contextTypes: ['OFFSCREEN_DOCUMENT'],
@@ -19,13 +19,11 @@ async function setupOffscreenDocument(path: string) {
 
   // @ts-expect-error - browser type is not complete
   await browser.offscreen.createDocument({
-    url: path,
+    url: offscreenUrl,
     reasons: ['LOCAL_STORAGE'],
     justification: 'handle wallet-aepp communication',
   });
-}
-
-setupOffscreenDocument(browser.runtime.getURL('offscreen.html'));
+})();
 
 export type PopupMessageData = {
   target?: 'background' | 'offscreen';
@@ -37,7 +35,7 @@ export type PopupMessageData = {
 };
 
 /**
- *   @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
+ * @see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#sending_an_asynchronous_response_using_sendresponse
  */
 function handleMessage(msg: PopupMessageData, _: any, sendResponse: Function) {
   if (msg.target === 'background') {


### PR DESCRIPTION
This PR fixes 2 issues that happens in the chrome extension's background process.

1. "window is not defined" - happening because we are including the polyfills for the browser which attempts to add the `browser` into `window` object, which does not exist in the background process.
![image](https://github.com/superhero-com/superhero-wallet/assets/8217670/cbcb38f8-3edc-4042-af1d-2a227d6af00b)

2. "Only a single offscreen document may be created." - happening because we are running `browser.runtime.getURL` twice.
![image](https://github.com/superhero-com/superhero-wallet/assets/8217670/cb96d2e5-e8e2-4560-ae60-99ad0c8784b3)
