### PR TITLE
Decouple aens claim and preclaim transactions

### DIFF
--- a/src/composables/aeSdk.ts
+++ b/src/composables/aeSdk.ts
@@ -198,7 +198,10 @@ export function useAeSdk() {
    */
   async function getDryAeSdk(): Promise<AeSdk> {
     if (!dryAeSdk) {
-      const nodeInstance = new Node(aeActiveNetworkSettings.value.nodeUrl, { ignoreVersion: true });
+      const nodeInstance = new Node(
+        aeActiveNetworkSettings.value.nodeUrl,
+        { ignoreVersion: true, retryCount: 0 },
+      );
       dryAeSdk = new AeSdk({
         nodes: [{
           name: activeNetworkName.value,

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -123,6 +123,7 @@ export const STORAGE_KEYS = {
   lastRoute: 'last-route',
   fungibleTokenList: 'fungible-token-list',
   fungibleTokenBalances: 'fungible-token-balances',
+  preclaimedNames: 'preclaimed-names',
   permissions: 'permissions',
   appsBrowserHistory: 'apps-browser-history',
   transactionsLatest: 'transactions-latest',

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -89,8 +89,10 @@ import {
   useMultisigAccounts,
   useNotifications,
   useUi,
+  useTopHeaderData,
 } from '@/composables';
 import { useTransferSendHandler } from '@/composables/transferSendHandler';
+import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
 import Header from '@/popup/components/Header.vue';
 import NodeConnectionStatus from '@/popup/components/NodeConnectionStatus.vue';
@@ -127,6 +129,8 @@ export default defineComponent({
     const { restoreLanguage } = useLanguages();
     const { restoreTransferSendForm } = useTransferSendHandler();
     const { multisigAccounts } = useMultisigAccounts({ pollingDisabled: true });
+    const { claimPreclaimedNames } = useAeNames({ pollingDisabled: true });
+    const { topBlockHeight } = useTopHeaderData();
 
     const innerElement = ref<HTMLDivElement>();
     const delayedShowHeader = ref(false);
@@ -202,6 +206,12 @@ export default defineComponent({
           router.push({ name: ROUTE_ACCOUNT });
         }
       },
+    );
+
+    watch(
+      topBlockHeight,
+      claimPreclaimedNames,
+      { immediate: true },
     );
 
     watch(

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -180,7 +180,11 @@
       "msg": "Only letters and numbers are allowed."
     },
     "name-exist": {
+      "title": "Name registration error",
       "msg": "This name is already registered."
+    },
+    "name-already-preclaimed": {
+      "msg": "Claim process for this name is already started."
     },
     "name-length": {
       "msg": "Names on SUPERHERO have to be a minimum of 13 characters."

--- a/src/popup/pages/Names/Claim.vue
+++ b/src/popup/pages/Names/Claim.vue
@@ -74,7 +74,6 @@ import {
   defineComponent,
   ref,
   computed,
-  nextTick,
 } from 'vue';
 import {
   AensName,
@@ -104,7 +103,6 @@ import {
   AE_COIN_PRECISION,
   AE_AENS_DOMAIN,
   AE_AENS_NAME_MAX_LENGTH,
-  AE_AENS_NAME_AUCTION_MAX_LENGTH,
 } from '@/protocols/aeternity/config';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
@@ -134,13 +132,9 @@ export default defineComponent({
 
     const { activeAccount } = useAccounts();
     const { openDefaultModal } = useModals();
-    const { getAeSdk } = useAeSdk();
+    const { getAeSdk, nodeNetworkId } = useAeSdk();
     const { isLoaderVisible, setLoaderVisible } = useUi();
-    const {
-      setPendingAutoExtendName,
-      updateOwnedNames,
-      updateNamePointer,
-    } = useAeNames();
+    const { addNameToClaimQueue, preclaimedNames } = useAeNames();
 
     const name = ref('');
     const autoExtend = ref(false);
@@ -179,6 +173,17 @@ export default defineComponent({
         setLoaderVisible(false);
         return;
       }
+      if (
+        preclaimedNames.value[nodeNetworkId.value!]
+        && Object.keys(preclaimedNames.value[nodeNetworkId.value!]).includes(fullName.value)
+      ) {
+        setLoaderVisible(false);
+        openDefaultModal({
+          title: t('modals.name-exist.title'),
+          msg: t('modals.name-already-preclaimed.msg'),
+        });
+        return;
+      }
 
       const aeSdk = await getAeSdk();
       const nameEntry = await aeSdk.api.getNameEntryByName(fullName.value).catch(() => false);
@@ -186,46 +191,14 @@ export default defineComponent({
       if (nameEntry) {
         setLoaderVisible(false);
         openDefaultModal({
-          title: t('modals.name-exist.msg'),
+          title: t('modals.name-exist.title'),
+          msg: t('modals.name-exist.msg'),
         });
       } else {
-        let claimTxHash;
-
-        try {
-          const { salt } = await aeSdk.aensPreclaim(fullName.value);
-          claimTxHash = (await aeSdk.aensClaim(fullName.value, salt, { waitMined: false })).hash;
-          if (autoExtend.value) {
-            setPendingAutoExtendName(fullName.value);
-          }
-          await nextTick();
-          router.push({ name: ROUTE_ACCOUNT_DETAILS_NAMES });
-        } catch (error: any) {
-          let msg = error.message;
-          if (msg.includes('is not enough to execute') || error.statusCode === 404) {
-            msg = t('pages.names.balance-error');
-          }
-          openDefaultModal({
-            icon: 'critical',
-            msg,
-          });
-          return;
-        } finally {
-          setLoaderVisible(false);
-        }
-
-        try {
-          await aeSdk.poll(claimTxHash);
-          if (AE_AENS_NAME_AUCTION_MAX_LENGTH < fullName.value.length) {
-            await updateNamePointer({
-              name: fullName.value,
-              address: activeAccount.value.address,
-            });
-          }
-        } catch (error: any) {
-          openDefaultModal({ msg: error.message });
-        } finally {
-          updateOwnedNames();
-        }
+        setLoaderVisible(false);
+        addNameToClaimQueue(fullName.value, activeAccount.value.address, autoExtend.value);
+        name.value = '';
+        router.push({ name: ROUTE_ACCOUNT_DETAILS_NAMES });
       }
     }
 

--- a/src/popup/pages/Names/NamesList.vue
+++ b/src/popup/pages/Names/NamesList.vue
@@ -26,7 +26,7 @@
 import { IonPage, IonContent } from '@ionic/vue';
 import { computed, defineComponent, onUnmounted } from 'vue';
 import { executeAndSetInterval } from '@/utils';
-import { useAccounts, useUi } from '@/composables';
+import { useAccounts, useAeSdk, useUi } from '@/composables';
 import { useAeNames } from '@/protocols/aeternity/composables/aeNames';
 
 import NameItem from '../../components/NameItem.vue';
@@ -46,10 +46,23 @@ export default defineComponent({
   setup() {
     const { isAppActive } = useUi();
     const { activeAccount } = useAccounts();
-    const { areNamesFetching, ownedNames, updateOwnedNames } = useAeNames();
+    const { nodeNetworkId } = useAeSdk();
+    const {
+      areNamesFetching, ownedNames, preclaimedNames, updateOwnedNames,
+    } = useAeNames();
 
     const namesForAccount = computed(
-      () => ownedNames.value.filter(({ owner }) => owner === activeAccount.value.address),
+      () => [
+        ...preclaimedNames.value[nodeNetworkId.value!]
+          ? Object.values(preclaimedNames.value[nodeNetworkId.value!])
+            .filter(({ address }) => address === activeAccount.value.address)
+            .map((preclaimedName) => ({
+              ...preclaimedName,
+              pending: true,
+            }))
+          : [],
+        ...ownedNames.value.filter(({ owner }) => owner === activeAccount.value.address),
+      ],
     );
 
     const id = executeAndSetInterval(() => {

--- a/src/popup/plugins/veeValidate.ts
+++ b/src/popup/plugins/veeValidate.ts
@@ -117,7 +117,7 @@ defineRule(
 export default () => {
   const { balance, updateBalances } = useBalances();
   const { currencyRates } = useCurrencies({ pollingDisabled: true });
-  const { getAeSdk } = useAeSdk();
+  const { getDryAeSdk } = useAeSdk();
 
   const NAME_STATES = {
     REGISTERED: Symbol('name state: registered'),
@@ -131,8 +131,8 @@ export default () => {
   const checkNameDebounced = debounce(
     async (name, expectedNameState, comparedAddress, { resolve, reject }) => {
       try {
-        const aeSdk = await getAeSdk();
-        const nameEntry = (await aeSdk.api.getNameEntryByName(name)) as any as NameEntry;
+        const dryAeSdk = await getDryAeSdk();
+        const nameEntry = (await dryAeSdk.api.getNameEntryByName(name)) as any as NameEntry;
         const address = getAddressByNameEntry(nameEntry);
         resolve(({
           [NAME_STATES.REGISTERED]: true,
@@ -155,14 +155,9 @@ export default () => {
     { leading: true },
   );
 
-  let lastName: string;
   function checkName(expectedNameState: ObjectValues<typeof NAME_STATES>) {
     return (name: string, [comparedAddress]: string[]): Promise<boolean> => new Promise(
       (resolve, reject) => {
-        if (name === lastName) {
-          checkNameDebounced.flush();
-        }
-        lastName = name;
         checkNameDebounced(name, expectedNameState, comparedAddress, { resolve, reject });
       },
     );

--- a/src/protocols/aeternity/libs/AeSdkSuperhero.ts
+++ b/src/protocols/aeternity/libs/AeSdkSuperhero.ts
@@ -31,7 +31,10 @@ export class AeSdkSuperhero extends AeSdkWallet {
     this.nodeNetworkId = nodeNetworkId;
   }
 
-  _resolveAccount() {
+  _resolveAccount(options: any) {
+    if (options) {
+      return super._resolveAccount(options);
+    }
     // TODO cache the account instead of instantiating it whenever the library is asked for it
     return new AeAccountHdWallet(this.nodeNetworkId);
   }


### PR DESCRIPTION
This PR includes several improvements:
 - fixes #661;
 - fixes #2200;
 - fixes #2645;
 - an account that claims a name will not be blocked from usage during claiming process (all other transactions while the name was in the claiming process were accumulated in a pending state and were not executed until the name was claimed)
 - fixes an issue that caused the pointer to not be set to the current account if the user navigated off the page, closed the extension, and so on;
 - allows to claim several names one by one without any problems;
 - pending name now appears instantly, claimed name will also appear instantly in the wallet
 - reduces the number of name check requests

