### PR TITLE
refactor: remove abi version from tx interface

### DIFF
--- a/src/constants/stubs.ts
+++ b/src/constants/stubs.ts
@@ -1,7 +1,5 @@
 import {
   Tag,
-  AbiVersion,
-  VmVersion,
   Encoded,
   AE_AMOUNT_FORMATS,
 } from '@aeternity/aepp-sdk';
@@ -132,8 +130,6 @@ const commonParams = {
     type: 'delta',
     value: 10,
   },
-  ctVersion: { abiVersion: AbiVersion.Sophia, vmVersion: VmVersion.Sophia },
-  abiVersion: AbiVersion.Sophia,
   callData: STUB_CALL_DATA,
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -454,7 +454,6 @@ export interface IGAMetaTx {
 }
 
 export interface ITx {
-  abiVersion?: number;
   accountId?: AccountAddress;
   aexnType?: 'aex9';
   amount: number;

--- a/tests/unit/transaction-details.spec.js
+++ b/tests/unit/transaction-details.spec.js
@@ -13,7 +13,6 @@ const getTransactions = (hasError) => ({
       microIndex: 23,
       microTime: 1656518730553,
       tx: {
-        abiVersion: 3,
         amount: 0,
         contractId: 'ct_MLXQEP12MBn99HL6WDaiTqDbG4bJQ3Q9Bzr57oLfvEkghvpFb',
         fee: 185260000000000,


### PR DESCRIPTION
Do we really need to provide and store this property?