### PR TITLE
refactor: remove transaction type property

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -527,7 +527,6 @@ export interface ITransaction {
    */
   transactionOwner?: AccountAddress;
   tx: ITx;
-  type?: string;
   url?: string;
   isMultisig?: false; // TODO Consider merging the ITransaction with IActiveMultisigTransaction
 }


### PR DESCRIPTION
Not sure why @konradodo added this type here: https://github.com/superhero-com/superhero-wallet/pull/2306/files#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R451
But as far as I see it's not used because the `ITx` has a `type` property with `TxType` type.