### PR TITLE
feat: show decoded call data on eth tx details

### DIFF
--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -145,64 +145,21 @@
           />
         </DetailsItem>
       </div>
-
       <DetailsItem
         expandable
+        class="advanced-transaction-details"
         :label="$t('transaction.advancedDetails')"
       >
-        <DetailsItem
-          v-if="transaction?.tx?.data"
-          :label="$t('transaction.data')"
-        >
-          <Tabs class="tabs">
-            <Tab
-              v-for="({ name, text }) in dataTabs"
-              :key="name"
-              :data-cy="name"
-              :name="name"
-              :text="text"
-              :active="activeTab === name"
-              @click="setActiveTab(name)"
-            />
-          </Tabs>
-          <div class="tabs-content">
-            <!-- Decoded Data -->
-            <DetailsItem v-if="activeTab === dataTabs[0].name">
-              <Panel v-if="decodedCallData?.args">
-                <PanelTableItem
-                  v-for="([key, value]) in Object.entries(decodedCallData?.args as any) || []"
-                  :key="key"
-                  :name="key"
-                >
-                  <div class="scrollable">
-                    {{ value }}
-                  </div>
-                </PanelTableItem>
-              </Panel>
-              <InfoBox
-                v-else
-                type="warning"
-                :text="$t('transaction.decodingDataFailed')"
-              />
-            </DetailsItem>
-            <!--
-              Raw Data
-              Display the ETH transaction raw data until we are able to decode it
-              into human readable arguments (e.g.: amount).
-            -->
-            <DetailsItem
-              v-if="activeTab === dataTabs[1].name"
-              :value="transaction.tx.data"
-            />
-          </div>
-        </DetailsItem>
-
+        <TransactionCallDataDetails
+          :call-data="transaction?.tx?.data"
+          :call-data-decoded="decodedCallData"
+          :loading="decodingCallData"
+        />
         <DetailsItem
           v-if="transactionArguments"
           :label="$t('modals.confirmTransactionSign.arguments')"
           :value="transactionArguments"
         />
-
         <DetailsItem
           v-for="key in filteredTxFields"
           :key="key"
@@ -310,11 +267,7 @@ import TransactionOverview from '../TransactionOverview.vue';
 import DetailsItem from '../DetailsItem.vue';
 import TokenAmount from '../TokenAmount.vue';
 import TransactionDetailsPoolTokenRow from '../TransactionDetailsPoolTokenRow.vue';
-import Panel from '../Panel.vue';
-import PanelTableItem from '../PanelTableItem.vue';
-import Tabs from '../tabs/Tabs.vue';
-import Tab from '../tabs/Tab.vue';
-import InfoBox from '../InfoBox.vue';
+import TransactionCallDataDetails from '../TransactionCallDataDetails.vue';
 
 import AnimatedSpinner from '../../../icons/animated-spinner.svg?vue-component';
 
@@ -345,11 +298,7 @@ export default defineComponent({
     DetailsItem,
     TokenAmount,
     TransactionDetailsPoolTokenRow,
-    PanelTableItem,
-    Panel,
-    Tabs,
-    Tab,
-    InfoBox,
+    TransactionCallDataDetails,
     AnimatedSpinner,
   },
   setup() {
@@ -410,6 +359,7 @@ export default defineComponent({
     const gasPrice = ref(0);
     const decodedCallData = ref<AeDecodedCallData | EthDecodedCallData | undefined>();
     const activeTab = ref(dataTabs[0].name);
+    const decodingCallData = ref(false);
 
     const app = computed(() => popupProps.value?.app);
 
@@ -645,11 +595,13 @@ export default defineComponent({
         && popupProps.value?.tx?.data
         && popupProps.value?.tx?.contractId
       ) {
+        decodingCallData.value = true;
         decodedCallData.value = await decodeTxData(
           popupProps.value.tx.data,
           popupProps.value.tx.contractId,
           activeAccount.address,
         );
+        decodingCallData.value = false;
       }
     }
 
@@ -688,6 +640,7 @@ export default defineComponent({
       cancel,
       decodedCallData,
       decodedPayload,
+      decodingCallData,
       direction,
       error,
       executionCost,
@@ -741,10 +694,6 @@ export default defineComponent({
     height: 56px;
   }
 
-  .scrollable {
-    word-break: keep-all;
-  }
-
   .subtitle {
     margin: 8px 0;
     color: $color-grey-light;
@@ -793,6 +742,10 @@ export default defineComponent({
 
   .button-action-primary {
     display: flex;
+  }
+
+  .advanced-transaction-details {
+    width:100%;
   }
 }
 </style>

--- a/src/popup/components/PanelTableItem.vue
+++ b/src/popup/components/PanelTableItem.vue
@@ -3,10 +3,13 @@
     :is="(href) ? 'LinkButton' : 'div'"
     :href="href"
     :is-external="isExternalLink"
-    :class="{
-      clickable: !!href,
-      'is-external': isExternalLink,
-    }"
+    :class="[
+      `variant-${variant}`,
+      {
+        clickable: !!href,
+        'is-external': isExternalLink,
+      },
+    ]"
     class="panel-table-item"
   >
     <div class="name">
@@ -19,9 +22,16 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 import LinkButton from '@/popup/components/LinkButton.vue';
+
+export const PANEL_TABLE_VARIANT = [
+  'default',
+  'left-aligned-name-bolder',
+] as const;
+
+export type LinkButtonVariant = typeof PANEL_TABLE_VARIANT[number];
 
 export default defineComponent({
   components: {
@@ -31,6 +41,11 @@ export default defineComponent({
     name: { type: String, required: true },
     href: { type: String, default: null },
     isExternalLink: Boolean,
+    variant: {
+      type: String as PropType<LinkButtonVariant>,
+      validator: (value: LinkButtonVariant) => PANEL_TABLE_VARIANT.includes(value),
+      default: PANEL_TABLE_VARIANT[0],
+    },
   },
 });
 </script>
@@ -85,6 +100,11 @@ export default defineComponent({
       margin-left: 4px;
       margin-right: -4px;
     }
+  }
+
+  &.variant-left-aligned-name-bolder .name {
+    font-weight: 500;
+    margin-right: 0;
   }
 
   &.clickable {

--- a/src/popup/components/TransactionCallDataDetails.vue
+++ b/src/popup/components/TransactionCallDataDetails.vue
@@ -1,0 +1,155 @@
+<template>
+  <DetailsItem
+    v-if="callData"
+    class="call-data-details"
+    :label="$t('transaction.data')"
+  >
+    <Tabs class="tabs">
+      <Tab
+        v-for="({ name, text }) in dataTabs"
+        :key="name"
+        :data-cy="name"
+        :text="text"
+        :active="activeTab === name"
+        @click="setActiveTab(name)"
+      />
+    </Tabs>
+    <div class="tabs-content">
+      <DetailsItem v-if="activeTab === dataTabs[0].name">
+        <AnimatedSpinner
+          v-if="loading"
+          class="loader"
+        />
+        <div v-else-if="callDataDecoded">
+          <DetailsItem
+            :label="$t('modals.confirmTransactionSign.functionName')"
+            :value="callDataDecoded?.functionName"
+          />
+          <DetailsItem :label="$t('modals.confirmTransactionSign.arguments')">
+            <template #value>
+              <Panel class="arguments">
+                <PanelTableItem
+                  v-for="([key, value]) in argumentsEntries"
+                  :key="key"
+                  :name="key"
+                  variant="left-aligned-name-bolder"
+                >
+                  <div class="value">
+                    {{ typeof value === 'bigint' ? Number(value) : value }}
+                  </div>
+                </PanelTableItem>
+              </Panel>
+            </template>
+          </DetailsItem>
+        </div>
+        <InfoBox
+          v-else
+          type="warning"
+          :text="$t('transaction.decodingDataFailed')"
+        />
+      </DetailsItem>
+
+      <!-- Raw Data -->
+      <DetailsItem
+        v-if="activeTab === dataTabs[1].name"
+        :value="callData"
+      />
+    </div>
+  </DetailsItem>
+</template>
+
+<script lang="ts">
+import {
+  computed,
+  defineComponent,
+  PropType,
+  ref,
+} from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import type { Dictionary } from '@/types';
+
+import Panel from '@/popup/components/Panel.vue';
+import PanelTableItem from '@/popup/components/PanelTableItem.vue';
+import Tabs from '@/popup/components/tabs/Tabs.vue';
+import Tab from '@/popup/components/tabs/Tab.vue';
+import InfoBox from '@/popup/components/InfoBox.vue';
+import DetailsItem from '@/popup/components/DetailsItem.vue';
+
+import AnimatedSpinner from '@/icons/animated-spinner.svg?vue-component';
+
+export default defineComponent({
+  name: 'TransactionCallDataDetails',
+  components: {
+    Panel,
+    PanelTableItem,
+    Tabs,
+    Tab,
+    InfoBox,
+    DetailsItem,
+    AnimatedSpinner,
+  },
+  props: {
+    callData: { type: String, default: null },
+    callDataDecoded: { type: Object as PropType<Dictionary>, default: null },
+    loading: Boolean,
+  },
+  setup(props) {
+    const { t } = useI18n();
+
+    const dataTabs = [
+      {
+        name: 'decoded',
+        text: t('transaction.decoded'),
+      },
+      {
+        name: 'raw',
+        text: t('transaction.rawData'),
+      },
+    ];
+
+    const activeTab = ref(dataTabs[0].name);
+
+    const argumentsEntries = computed(
+      () => props.callDataDecoded?.args
+        ? Object.entries(props.callDataDecoded.args)
+          .filter(([key]) => !Number.isNaN(parseInt(key, 10)))
+        : undefined,
+    );
+
+    function setActiveTab(tabName: string) {
+      activeTab.value = tabName;
+    }
+
+    return {
+      dataTabs,
+      activeTab,
+      argumentsEntries,
+      setActiveTab,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.call-data-details {
+  width: 100%;
+
+  .tabs-content {
+    .loader {
+      height: 70px;
+      width: 100%;
+    }
+
+    .value {
+      text-align: left;
+      line-height: 15px;
+      word-break: break-all;
+    }
+
+    .arguments {
+      margin-top: 8px;
+    }
+  }
+}
+</style>

--- a/src/protocols/ethereum/helpers/index.ts
+++ b/src/protocols/ethereum/helpers/index.ts
@@ -131,6 +131,8 @@ export async function decodeTxData(
 
   try {
     // Decode the method and parameters from the input data
+    // TODO contractInstance doesn't always have the method signatures
+    // then we are not able to decode the method name and get the parameters
     const methodSignature = txData.slice(0, 10);
     const method = contractInstance.options.jsonInterface
       .find((m) => m.signature === methodSignature);

--- a/src/protocols/ethereum/helpers/index.ts
+++ b/src/protocols/ethereum/helpers/index.ts
@@ -118,7 +118,7 @@ export async function decodeTxData(
       address: contractId,
     });
 
-  if (contractAbi?.message !== 'OK') {
+  if (!contractAbi?.message?.startsWith('OK')) {
     return undefined;
   }
   const parsedAbi = JSON.parse(contractAbi.result);
@@ -139,7 +139,7 @@ export async function decodeTxData(
 
     return {
       functionName: (method as any).name,
-      args: params[0] as Dictionary,
+      args: params as Dictionary,
     };
   } catch (e) {
     handleUnknownError(e);

--- a/src/protocols/ethereum/libs/EthereumAdapter.ts
+++ b/src/protocols/ethereum/libs/EthereumAdapter.ts
@@ -424,6 +424,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
         hash,
         transactionOwner ?? transaction.from,
         transaction.blockNumber,
+        transaction.input,
       );
 
       if (tokenTx) {

--- a/src/protocols/ethereum/libs/EtherscanService.ts
+++ b/src/protocols/ethereum/libs/EtherscanService.ts
@@ -138,13 +138,25 @@ export class EtherscanService {
     hash: string,
     address: string,
     blockNumber: string,
+    input?: string,
   ): Promise<ITransaction | undefined> {
     // Not the best solution, but it seems to be the only way to get token transaction details
     const blockTransactions = await this.fetchAccountTokenTransactions(address, {
       startblock: blockNumber,
       endblock: blockNumber,
     });
-    return blockTransactions.find((tx) => tx.hash === hash);
+
+    // The token transaction API doesn't always return input data, so we are adding it manually
+    // if we have it from the previous call
+    const transaction = blockTransactions.find((tx) => tx.hash === hash);
+    if (
+      transaction
+      && input
+      && (!transaction?.tx?.callData || (transaction?.tx?.callData as any) === 'deprecated')
+    ) {
+      transaction.tx.callData = input as any;
+    }
+    return transaction;
   }
 
   static normalizeEtherscanTransactionStructure(

--- a/src/protocols/ethereum/libs/EtherscanService.ts
+++ b/src/protocols/ethereum/libs/EtherscanService.ts
@@ -164,6 +164,7 @@ export class EtherscanService {
       timeStamp,
       to,
       value,
+      input,
     } = transaction;
 
     const senderId = toEthChecksumAddress(from) as any;
@@ -178,7 +179,7 @@ export class EtherscanService {
     const amount = Number(fromWei(value, 'ether'));
     const pending = parseInt(confirmations, 10) <= ETH_SAFE_CONFIRMATION_COUNT;
     const microTime = timeStamp * 1000;
-    const isEthTransfer = !contractAddress;
+    const isEthTransfer = !contractAddress && !input;
 
     return {
       protocol: PROTOCOLS.ethereum,
@@ -194,6 +195,7 @@ export class EtherscanService {
         type: isEthTransfer ? 'SpendTx' : 'ContractCallTx', // TODO: create own types
         arguments: [],
         callerId: isEthTransfer ? '' as any : senderId,
+        callData: isEthTransfer ? null : input,
         contractId,
         function: functionName,
         nonce,

--- a/src/protocols/ethereum/views/TransactionDetails.vue
+++ b/src/protocols/ethereum/views/TransactionDetails.vue
@@ -44,6 +44,17 @@
                 :label="$t('pages.transactionDetails.gasUsed')"
                 data-cy="gas"
               />
+              <DetailsItem
+                expandable
+                class="advanced-transaction-details"
+                :label="$t('transaction.advancedDetails')"
+              >
+                <TransactionCallDataDetails
+                  :call-data="transaction.tx.callData"
+                  :call-data-decoded="decodedCallData"
+                  :loading="decodingCallData"
+                />
+              </DetailsItem>
             </template>
           </TransactionDetailsBase>
         </template>
@@ -77,11 +88,13 @@ import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import { ROUTE_NOT_FOUND } from '@/popup/router/routeNames';
 
 import { ETH_COIN_SYMBOL } from '@/protocols/ethereum/config';
+import { decodeTxData } from '@/protocols/ethereum/helpers';
 
 import TransactionDetailsBase from '@/popup/components/TransactionDetailsBase.vue';
 import TransactionAssetRows from '@/popup/components/TransactionAssetRows.vue';
 import DetailsItem from '@/popup/components/DetailsItem.vue';
 import TokenAmount from '@/popup/components/TokenAmount.vue';
+import TransactionCallDataDetails from '@/popup/components/TransactionCallDataDetails.vue';
 
 export default defineComponent({
   components: {
@@ -91,6 +104,7 @@ export default defineComponent({
     TokenAmount,
     IonContent,
     IonPage,
+    TransactionCallDataDetails,
   },
   setup() {
     const router = useRouter();
@@ -101,6 +115,8 @@ export default defineComponent({
     const adapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.ethereum);
 
     const transaction = ref<ITransaction>();
+    const decodedCallData = ref();
+    const decodingCallData = ref(false);
 
     const { setLoaderVisible } = useUi();
     const { activeAccount } = useAccounts();
@@ -109,6 +125,7 @@ export default defineComponent({
       amountTotal,
       transactionAssets,
       isTransactionCoin,
+      innerTx,
     } = useTransactionData({
       transaction,
       transactionCustomOwner: toRef(() => transactionOwner),
@@ -123,10 +140,24 @@ export default defineComponent({
     const fee = computed((): number => transaction.value?.tx?.fee || 0);
     const amount = computed((): number => transaction.value?.tx?.amount || 0);
 
+    async function getDecodedCallData() {
+      if (innerTx.value?.callData && innerTx.value?.recipientId) {
+        return decodeTxData(
+          innerTx.value.callData,
+          innerTx.value.recipientId,
+          activeAccount.value.address,
+        );
+      }
+      return null;
+    }
+
     watch(
       transaction,
-      (value) => {
+      async (value) => {
         setLoaderVisible(!value);
+        decodingCallData.value = true;
+        decodedCallData.value = await getDecodedCallData();
+        decodingCallData.value = false;
       },
       { immediate: true },
     );
@@ -170,6 +201,8 @@ export default defineComponent({
       PROTOCOLS,
       amount,
       amountTotal,
+      decodedCallData,
+      decodingCallData,
       isTransactionCoin,
       hash,
       fee,
@@ -179,3 +212,11 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.transaction-details {
+  .advanced-transaction-details {
+    width:100%;
+  }
+}
+</style>

--- a/tests/unit/__snapshots__/snapshot.spec.js.snap
+++ b/tests/unit/__snapshots__/snapshot.spec.js.snap
@@ -19,7 +19,7 @@ exports[`Pages About 1`] = `
         >
           
           <div
-            class="panel-table-item"
+            class="variant-default panel-table-item"
             is-external="false"
           >
             <div
@@ -36,7 +36,7 @@ exports[`Pages About 1`] = `
             </div>
           </div>
           <a
-            class="link-button variant-default clickable panel-table-item"
+            class="link-button variant-default variant-default clickable panel-table-item"
             href="https://github.com/aeternity/superhero-wallet/commit/a1c1c5acc851c49248aad87088963f9ae5fb200e"
             rel="noopener noreferrer"
             target="_blank"
@@ -61,7 +61,7 @@ exports[`Pages About 1`] = `
             <!--v-if-->
           </a>
           <div
-            class="panel-table-item"
+            class="variant-default panel-table-item"
             is-external="false"
           >
             <div
@@ -78,7 +78,7 @@ exports[`Pages About 1`] = `
             </div>
           </div>
           <div
-            class="panel-table-item"
+            class="variant-default panel-table-item"
             is-external="false"
           >
             <div


### PR DESCRIPTION
closes #3097 
closes #3096 

Show user decoded data (if possible, if not show raw data) in transaction details so that he can figure out what the contract call did. This does not exactly solve the issues but seems like the best solution. Etherscan also only shows the decoded data since it would be impossible to create resolvers/parsers for every contract out there 