### PR TITLE
Improve `showHeader` logic

### DIFF
--- a/src/popup/router/routes.ts
+++ b/src/popup/router/routes.ts
@@ -694,6 +694,7 @@ export const routes: WalletAppRouteConfig[] = [
     meta: {
       title: 'address',
       notPersist: true,
+      hideHeader: true,
     },
   },
   {
@@ -779,6 +780,7 @@ export const routes: WalletAppRouteConfig[] = [
     meta: {
       title: 'signMessage',
       notPersist: true,
+      hideHeader: true,
     },
   },
   {
@@ -788,6 +790,7 @@ export const routes: WalletAppRouteConfig[] = [
     meta: {
       title: 'signTransaction',
       notPersist: true,
+      hideHeader: true,
     },
   },
   {
@@ -797,6 +800,7 @@ export const routes: WalletAppRouteConfig[] = [
     meta: {
       title: 'signMessage',
       notPersist: true,
+      hideHeader: true,
     },
   },
   {


### PR DESCRIPTION
The `Header` was not displayed if the `hideHeader` parameter in the `route.meta` was set to `true`, but in this case notification polling was started (initial calculation of Header that required `notification` composable was done).