### PR TITLE
feat: export error log and show error modals on transaction errors

### DIFF
--- a/src/composables/modals.ts
+++ b/src/composables/modals.ts
@@ -174,8 +174,11 @@ export function useModals() {
     return openModal(MODAL_CONFIRM, options);
   }
 
-  function openErrorModal(entry: Record<string, any>) {
-    return openModal(MODAL_ERROR_LOG, { entry }).catch(handleUnknownError);
+  function openErrorModal(options: {
+    title?: string;
+    msg?: string;
+  }) {
+    return openModal(MODAL_ERROR_LOG, options).catch(handleUnknownError);
   }
 
   function openScanQrModal(options: {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -326,6 +326,7 @@ export const MODAL_CONFIRM_RAW_SIGN = 'confirm-raw-sign';
 export const MODAL_CONFIRM_UNSAFE_SIGN = 'confirm-unsafe-sign';
 export const MODAL_CONFIRM_CONNECT = 'confirm-connect';
 export const MODAL_CONFIRM_ACCOUNT_LIST = 'confirm-account-list';
+export const MODAL_CONFIRM_DISABLE_ERROR_LOG = 'confirm-disable-error-log';
 export const MODAL_CONSENSUS_INFO = 'consensus-info';
 export const MODAL_DEFAULT = 'default';
 export const MODAL_ERROR_LOG = 'error-log';
@@ -567,3 +568,5 @@ export const ACCOUNT_SELECT_TYPE_FILTER = {
   recent: 'recent',
 } as const;
 export type AccountSelectTypeFilter = ObjectValues<typeof ACCOUNT_SELECT_TYPE_FILTER>;
+
+export const MAX_LOG_ENTRIES = 1000;

--- a/src/popup/components/AddressBook/AddressBookList.vue
+++ b/src/popup/components/AddressBook/AddressBookList.vue
@@ -255,6 +255,7 @@ export default defineComponent({
   .address-book-item {
     background-color: var(--bg-color);
     border: var(--border-width) solid var(--bg-color);
+    padding: 8px 2px 8px 8px;
   }
 
   .search-field {

--- a/src/popup/components/InputField.vue
+++ b/src/popup/components/InputField.vue
@@ -356,7 +356,7 @@ export default defineComponent({
   .input-wrapper {
     position: relative;
     display: block;
-    padding: 10px 8px 12px 10px; // Decides on the input size
+    padding: 10px 8px 10px 10px; // Decides on the input size
     background-color: var(--color-bg);
     border: none;
     border-radius: $border-radius-interactive;

--- a/src/popup/components/Modals/ConfirmDisableErrorLog.vue
+++ b/src/popup/components/Modals/ConfirmDisableErrorLog.vue
@@ -1,0 +1,147 @@
+<template>
+  <Modal
+    class="confirm"
+    has-close-button
+    from-bottom
+    no-padding
+    @close="reject"
+  >
+    <div class="content">
+      <div class="icon-wrapper">
+        <IconBoxed>
+          <IconWrapper
+            :icon="ExportIcon"
+            icon-size="xl"
+            class="icon"
+          />
+        </IconBoxed>
+      </div>
+      <h2
+        class="text-heading-4 text-center"
+        v-text="$t('pages.errors-log-settings.disableDialog.title')"
+      />
+      <div
+        class="subtitle text-center"
+        v-text="$t('pages.errors-log-settings.disableDialog.subtitle')"
+      />
+      <div
+        class="msg"
+        v-text="$t('pages.errors-log-settings.disableDialog.msg')"
+      />
+      <div
+        class="question"
+        v-text="$t('pages.errors-log-settings.disableDialog.question')"
+      />
+    </div>
+
+    <template #footer>
+      <div class="footer">
+        <BtnMain
+          variant="muted"
+          :text="$t('common.cancel')"
+          @click="reject"
+        />
+        <BtnMain
+          variant="primary"
+          extra-padded
+          :text="$t('pages.errors-log-settings.disableDialog.btnText')"
+          @click="resolve"
+        />
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  PropType,
+} from 'vue';
+import type {
+  RejectCallback,
+  ResolveCallback,
+} from '@/types';
+
+import IconBoxed from '@/popup/components/IconBoxed.vue';
+import IconWrapper from '@/popup/components/IconWrapper.vue';
+import Modal from '@/popup/components/Modal.vue';
+import BtnMain from '@/popup/components/buttons/BtnMain.vue';
+
+import ExportIcon from '@/icons/export-address-book.svg?vue-component';
+
+export default defineComponent({
+  components: {
+    IconWrapper,
+    Modal,
+    BtnMain,
+    IconBoxed,
+  },
+  props: {
+    resolve: {
+      type: Function as PropType<ResolveCallback<boolean>>,
+      required: true,
+    },
+    reject: { type: Function as PropType<RejectCallback>, required: true },
+  },
+  setup() {
+    return {
+      ExportIcon,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/styles/variables' as *;
+@use '@/styles/typography';
+
+.confirm {
+  text-align: center;
+
+  .content {
+    padding: 8px 24px;
+  }
+
+  .text-heading-4 {
+    margin-bottom: 4px;
+  }
+
+  .subtitle {
+    @extend %face-sans-16-medium;
+
+    margin-bottom: 20px;
+  }
+
+  .msg {
+    @extend %face-sans-15-regular;
+
+    color: rgba($color-white, 0.85);
+    margin-bottom: 10px;
+  }
+
+  .question {
+    @extend %face-sans-15-semi-bold;
+
+    color: rgba($color-white, 0.85);
+    margin-bottom: 20px;
+  }
+
+  .icon-wrapper {
+    margin-bottom: 20px;
+
+    .icon {
+      background-color: rgba($color-primary, 0.4);
+      color: $color-primary;
+    }
+  }
+
+  .footer {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    padding-bottom: 24px;
+    padding-inline: 24px;
+  }
+}
+</style>

--- a/src/popup/components/Modals/ErrorLog.vue
+++ b/src/popup/components/Modals/ErrorLog.vue
@@ -1,92 +1,72 @@
 <template>
-  <Modal
-    has-close-button
-    @close="resolve"
+  <Default
+    v-bind="{ ...$attrs, resolve }"
+    :title="title"
+    :msg="msg"
+    icon="critical"
+    text-center
+    class="error-modal"
   >
-    <h2 class="text-heading-4 text-center">
-      {{ $t('modals.error-log.title') }}
-    </h2>
-
-    <div class="error-msg">
-      {{ messageTruncated }}...
-    </div>
-    <div>
-      <span>{{ $t('modals.error-log.sub-title') }}</span>
-      {{ $t('modals.error-log.content') }}
-    </div>
-
     <template #footer>
       <BtnMain
+        v-if="saveErrorLogEnabled"
         variant="muted"
-        @click="cancel"
-      >
-        {{ $t('common.cancel') }}
-      </BtnMain>
-      <BtnMain @click="createReport">
-        {{ $t('modals.error-log.create-report') }}
-      </BtnMain>
+        class="center-button"
+        :text="$t('pages.errors-log-settings.exportErrorLog')"
+        :icon="ExportIcon"
+        @click="exportErrorLog"
+      />
+      <BtnMain
+        class="center-button"
+        :text="$t('common.ok')"
+        @click="resolve"
+      />
     </template>
-  </Modal>
+  </Default>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue';
-import { useRouter } from 'vue-router';
-import type { RejectCallback, ResolveCallback } from '../../../types';
-import { RejectedByUserError } from '../../../lib/errors';
-import { ROUTE_DONATE_ERROR } from '../../router/routeNames';
-import Modal from '../Modal.vue';
-import BtnMain from '../buttons/BtnMain.vue';
+import type { ResolveCallback } from '@/types';
+import Logger from '@/lib/logger';
+
+import Default from '@/popup/components/Modals/Default.vue';
+import BtnMain from '@/popup/components/buttons/BtnMain.vue';
+
+import ExportIcon from '@/icons/export-address-book.svg?vue-component';
 
 export default defineComponent({
   components: {
-    Modal,
+    Default,
     BtnMain,
   },
   props: {
     resolve: { type: Function as PropType<ResolveCallback>, required: true },
-    reject: { type: Function as PropType<RejectCallback>, required: true },
-    entry: { type: Object, required: true },
+    title: { type: String, default: '' },
+    msg: { type: String, default: '' },
   },
-  setup(props) {
-    const router = useRouter();
+  setup({ resolve }) {
+    const saveErrorLogEnabled = computed(() => Logger.saveErrorLog.value);
 
-    const messageTruncated = computed(() => {
-      const { message = '' } = props.entry.error;
-      return message.substr(0, 150);
-    });
-
-    function cancel() {
-      props.reject(new RejectedByUserError());
-    }
-
-    function createReport() {
-      props.resolve(true);
-      router.push({
-        name: ROUTE_DONATE_ERROR,
-        params: { entry: props.entry as any },
-      });
+    function exportErrorLog() {
+      Logger.exportErrorLog();
+      resolve();
     }
 
     return {
-      messageTruncated,
-      cancel,
-      createReport,
+      saveErrorLogEnabled,
+      exportErrorLog,
+      ExportIcon,
     };
   },
 });
 </script>
 
 <style lang="scss" scoped>
-@use '@/styles/variables' as *;
-
-.error-msg {
-  color: $color-danger;
-  margin-bottom: 30px;
-}
-
-span {
-  display: block;
-  font-weight: bold;
+.error-modal {
+  .center-button {
+    width: auto;
+    padding: 0 24px;
+  }
 }
 </style>

--- a/src/popup/components/Modals/MultisigVaultCreate.vue
+++ b/src/popup/components/Modals/MultisigVaultCreate.vue
@@ -210,7 +210,7 @@ import { Encoded } from '@aeternity/aepp-sdk';
 
 import type { ICreateMultisigAccount, ObjectValues } from '@/types';
 import { MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR, PROTOCOLS } from '@/constants';
-import { excludeFalsy, handleUnknownError } from '@/utils';
+import { excludeFalsy } from '@/utils';
 import { ROUTE_MULTISIG_ACCOUNT } from '@/popup/router/routeNames';
 import {
   useAccounts,
@@ -240,6 +240,7 @@ import CircleCloseIcon from '@/icons/circle-close.svg?vue-component';
 import QrScanIcon from '@/icons/qr-scan.svg?vue-component';
 import AddressBookIcon from '@/icons/menu-card-fill.svg?vue-component';
 import PlusCircleIcon from '@/icons/plus-circle.svg?vue-component';
+import Logger from '@/lib/logger';
 
 const STEPS = {
   form: 'form',
@@ -426,12 +427,11 @@ export default defineComponent({
           signersAddressList.value,
         );
       } catch (error: any) {
-        handleUnknownError(error);
-        await openDefaultModal({
+        Logger.write({
           title: t('multisig.multisigVaultCreationFailed'),
-          icon: 'critical',
-          msg: error?.details?.reason,
-          textCenter: true,
+          message: error?.details?.reason || '',
+          type: 'api-response',
+          modal: true,
         });
         currentStep.value = STEPS.form;
       }

--- a/src/popup/components/buttons/BtnSubheader.vue
+++ b/src/popup/components/buttons/BtnSubheader.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   display: flex;
   align-items: center;
   width: 100%;
-  padding: 20px 12px;
+  padding: 20px 16px;
   border-radius: $border-radius-interactive;
   color: $color-white;
 

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -617,7 +617,7 @@
       "txDetails": "Transaction details",
       "tokenDetails": "Token details",
       "coinDetails": "Coin details",
-      "saveErrorsLog": "Save error log",
+      "saveErrorsLog": "Error log",
       "resetWallet": "Reset wallet",
       "seedPhrase": "Seed phrase",
       "secureLogin": "Secure login",
@@ -631,7 +631,16 @@
       "addressBookAdd": "Add new address"
     },
     "errors-log-settings": {
-      "description": "This will help us to identify what causes the errors. Thank you for being a fellow Superhero!"
+      "description": "<p>Superhero Wallet is able of maintaining an error log file on your device, recording the last {0} errors encountered.</p><p>The error log can be exported in JSON format to facilitate debugging or support assistance.</p>",
+      "keepErrorLog": "Keep error log",
+      "exportErrorLog": "Export error log",
+      "disableDialog": {
+        "title": "Disable error log",
+        "subtitle": "and export collected data",
+        "msg": "You are about to disable keeping an error log for Superhero Wallet. This will delete all previous error data saved in the storage.",
+        "question": "Would you like to export the error log and disable the feature?",
+        "btnText": "Export and disable"
+      }
     },
     "addressBook": {
       "addAddress": "Add",

--- a/src/popup/pages/SignTransaction.vue
+++ b/src/popup/pages/SignTransaction.vue
@@ -22,6 +22,7 @@ import {
   useUi,
   useAccounts,
 } from '@/composables';
+import Logger from '@/lib/logger';
 
 export default defineComponent({
   name: 'SignTransaction',
@@ -98,16 +99,17 @@ export default defineComponent({
           openCallbackOrGoHome(true, { transaction: signedTransaction });
         }
       } catch (error: any) {
-        await openDefaultModal({
-          title: t('modals.transaction-failed.msg'),
-          icon: 'critical',
-          msg: error.message,
-        });
-        openCallbackOrGoHome(false);
-
         if (error instanceof RejectedByUserError) {
           handleUnknownError(error);
+        } else {
+          Logger.write({
+            title: t('modals.transaction-failed.title'),
+            message: error.message || t('modals.transaction-failed.msg'),
+            type: 'api-response',
+            modal: true,
+          });
         }
+        openCallbackOrGoHome(false);
       } finally {
         setLoaderVisible(false);
       }

--- a/src/popup/router/modals.ts
+++ b/src/popup/router/modals.ts
@@ -11,6 +11,7 @@ import {
   MODAL_CONFIRM_RAW_SIGN,
   MODAL_CONFIRM_UNSAFE_SIGN,
   MODAL_CONFIRM_TRANSACTION_SIGN,
+  MODAL_CONFIRM_DISABLE_ERROR_LOG,
   MODAL_CONSENSUS_INFO,
   MODAL_DEFAULT,
   MODAL_ERROR_LOG,
@@ -50,49 +51,50 @@ import { useModals } from '@/composables';
 
 import NetworkSwitcherModal from '@/popup/components/Modals/NetworkSwitcherModal.vue';
 
-import AccountCreate from '../components/Modals/AccountCreate.vue';
-import Default from '../components/Modals/Default.vue';
-import ProtocolSpecificView from '../components/ProtocolSpecificView.vue';
-import ProtocolSelect from '../components/Modals/ProtocolSelect.vue';
-import AccountImport from '../components/Modals/AccountImport.vue';
-import AccountSelectOptions from '../components/Modals/AccountSelectOptions.vue';
-import ClaimSuccess from '../components/Modals/ClaimSuccess.vue';
-import Confirm from '../components/Modals/Confirm.vue';
-import ConfirmConnect from '../pages/Popups/Connect.vue';
-import ConfirmAccountList from '../pages/Popups/AccountList.vue';
+import ConfirmDisableErrorLog from '@/popup/components/Modals/ConfirmDisableErrorLog.vue';
+import AccountCreate from '@/popup/components/Modals/AccountCreate.vue';
+import Default from '@/popup/components/Modals/Default.vue';
+import ProtocolSpecificView from '@/popup/components/ProtocolSpecificView.vue';
+import ProtocolSelect from '@/popup/components/Modals/ProtocolSelect.vue';
+import AccountImport from '@/popup/components/Modals/AccountImport.vue';
+import AccountSelectOptions from '@/popup/components/Modals/AccountSelectOptions.vue';
+import ClaimSuccess from '@/popup/components/Modals/ClaimSuccess.vue';
+import Confirm from '@/popup/components/Modals/Confirm.vue';
+import ConfirmConnect from '@/popup/pages/Popups/Connect.vue';
+import ConfirmAccountList from '@/popup/pages/Popups/AccountList.vue';
 
-import ErrorLog from '../components/Modals/ErrorLog.vue';
-import PrivateKeyExport from '../components/Modals/PrivateKeyExport.vue';
-import FormSelectOptions from '../components/Modals/FormSelectOptions.vue';
-import ConfirmTransactionSign from '../components/Modals/ConfirmTransactionSign.vue';
-import ConfirmRawSign from '../components/Modals/ConfirmRawSign.vue';
-import ConfirmUnsafeSign from '../components/Modals/ConfirmUnsafeSign.vue';
-import QrCodeScanner from '../components/Modals/QrCodeScanner.vue';
-import Help from '../components/Modals/Help.vue';
-import AssetSelector from '../components/Modals/AssetSelector.vue';
-import ResetWallet from '../components/Modals/ResetWalletModal.vue';
-import RecipientHelper from '../components/Modals/RecipientHelper.vue';
-import RecipientInfo from '../components/Modals/RecipientInfo.vue';
-import ConsensusInfo from '../components/Modals/ConsensusInfo.vue';
-import PayloadForm from '../components/Modals/PayloadForm.vue';
-import ClaimGiftCard from '../components/Modals/ClaimGiftCard.vue';
-import MultisigVaultCreate from '../components/Modals/MultisigVaultCreate.vue';
-import WarningDappBrowser from '../components/Modals/WarningDappBrowser.vue';
-import MultisigProposalConfirmActions from '../components/Modals/MultisigProposalConfirmActions.vue';
-import MessageSign from '../pages/Popups/MessageSign.vue';
-import BrowserActions from '../components/Modals/BrowserActions.vue';
-import BiometricLogin from '../components/Modals/BiometricLogin.vue';
-import EnableBiometricLogin from '../components/Modals/EnableBiometricLogin.vue';
-import WalletConnect from '../components/Modals/WalletConnectModal.vue';
-import AirGapImportAccounts from '../components/Modals/AirGapImportAccounts.vue';
-import SignAirGapTransaction from '../components/Modals/SignAirGapTransaction.vue';
-import AddressBookImport from '../components/Modals/AddressBookImport.vue';
-import ShareAddress from '../components/ShareAddress.vue';
-import AddressBookAccountSelector from '../components/Modals/AddressBookAccountSelector.vue';
-import SetPassword from '../components/Modals/SetPassword.vue';
-import PasswordLogin from '../components/Modals/PasswordLogin.vue';
-import PrivateKeyImport from '../components/Modals/PrivateKeyImport.vue';
-import PermissionManager from '../components/Modals/PermissionManager.vue';
+import ErrorLog from '@/popup/components/Modals/ErrorLog.vue';
+import PrivateKeyExport from '@/popup/components/Modals/PrivateKeyExport.vue';
+import FormSelectOptions from '@/popup/components/Modals/FormSelectOptions.vue';
+import ConfirmTransactionSign from '@/popup/components/Modals/ConfirmTransactionSign.vue';
+import ConfirmRawSign from '@/popup/components/Modals/ConfirmRawSign.vue';
+import ConfirmUnsafeSign from '@/popup/components/Modals/ConfirmUnsafeSign.vue';
+import QrCodeScanner from '@/popup/components/Modals/QrCodeScanner.vue';
+import Help from '@/popup/components/Modals/Help.vue';
+import AssetSelector from '@/popup/components/Modals/AssetSelector.vue';
+import ResetWallet from '@/popup/components/Modals/ResetWalletModal.vue';
+import RecipientHelper from '@/popup/components/Modals/RecipientHelper.vue';
+import RecipientInfo from '@/popup/components/Modals/RecipientInfo.vue';
+import ConsensusInfo from '@/popup/components/Modals/ConsensusInfo.vue';
+import PayloadForm from '@/popup/components/Modals/PayloadForm.vue';
+import ClaimGiftCard from '@/popup/components/Modals/ClaimGiftCard.vue';
+import MultisigVaultCreate from '@/popup/components/Modals/MultisigVaultCreate.vue';
+import WarningDappBrowser from '@/popup/components/Modals/WarningDappBrowser.vue';
+import MultisigProposalConfirmActions from '@/popup/components/Modals/MultisigProposalConfirmActions.vue';
+import MessageSign from '@/popup/pages/Popups/MessageSign.vue';
+import BrowserActions from '@/popup/components/Modals/BrowserActions.vue';
+import BiometricLogin from '@/popup/components/Modals/BiometricLogin.vue';
+import EnableBiometricLogin from '@/popup/components/Modals/EnableBiometricLogin.vue';
+import WalletConnect from '@/popup/components/Modals/WalletConnectModal.vue';
+import AirGapImportAccounts from '@/popup/components/Modals/AirGapImportAccounts.vue';
+import SignAirGapTransaction from '@/popup/components/Modals/SignAirGapTransaction.vue';
+import AddressBookImport from '@/popup/components/Modals/AddressBookImport.vue';
+import ShareAddress from '@/popup/components/ShareAddress.vue';
+import AddressBookAccountSelector from '@/popup/components/Modals/AddressBookAccountSelector.vue';
+import SetPassword from '@/popup/components/Modals/SetPassword.vue';
+import PasswordLogin from '@/popup/components/Modals/PasswordLogin.vue';
+import PrivateKeyImport from '@/popup/components/Modals/PrivateKeyImport.vue';
+import PermissionManager from '@/popup/components/Modals/PermissionManager.vue';
 
 export default () => {
   const { registerModal } = useModals();
@@ -152,6 +154,10 @@ export default () => {
   });
   registerModal(MODAL_CONFIRM_ACCOUNT_LIST, {
     component: ConfirmAccountList,
+    showInPopupIfWebFrame: true,
+  });
+  registerModal(MODAL_CONFIRM_DISABLE_ERROR_LOG, {
+    component: ConfirmDisableErrorLog,
     showInPopupIfWebFrame: true,
   });
   registerModal(MODAL_PRIVATE_KEY_EXPORT, {

--- a/src/protocols/aeternity/components/TransferSignedTxReview.vue
+++ b/src/protocols/aeternity/components/TransferSignedTxReview.vue
@@ -125,6 +125,7 @@ import AvatarWithChainName from '@/popup/components/AvatarWithChainName.vue';
 import ModalHeader from '@/popup/components/ModalHeader.vue';
 import BtnHelp from '@/popup/components/buttons/BtnHelp.vue';
 import FormScanQrResult from '@/popup/components/form/FormScanQrResult.vue';
+import Logger from '@/lib/logger';
 
 export default defineComponent({
   name: 'TransferSignedTxReview',
@@ -231,10 +232,12 @@ export default defineComponent({
           },
         };
         addAccountPendingTransaction(activeAccount.value.address, tempTransaction);
-      } catch (e) {
-        openModal(MODAL_DEFAULT, {
+      } catch (error: any) {
+        Logger.write({
           title: tg('modals.transaction-failed.title'),
-          icon: 'critical',
+          message: error.message || tg('modals.transaction-failed.msg'),
+          type: 'api-response',
+          modal: true,
         });
       }
     }

--- a/src/protocols/aeternity/libs/AeAccountHdWallet.ts
+++ b/src/protocols/aeternity/libs/AeAccountHdWallet.ts
@@ -27,6 +27,7 @@ import { useModals } from '@/composables/modals';
 import { useAccounts } from '@/composables/accounts';
 import { useAeMiddleware } from '@/protocols/aeternity/composables';
 import { usePermissions } from '@/composables/permissions';
+import Logger from '@/lib/logger';
 
 interface InternalOptions {
   fromAccount?: Encoded.AccountAddress;
@@ -114,13 +115,11 @@ export class AeAccountHdWallet extends MemoryAccount {
   ): Promise<Uint8Array> {
     const account = AeAccountHdWallet.getAccount(options?.fromAccount);
     if (account && isAccountAirGap(account)) {
-      const { openDefaultModal } = useModals();
-
-      openDefaultModal({
+      Logger.write({
         title: tg('airGap.signMessageErrorModal.title'),
-        msg: tg('airGap.signMessageErrorModal.msg'),
-        icon: 'critical',
-        textCenter: true,
+        message: tg('airGap.signMessageErrorModal.msg'),
+        type: 'api-response',
+        modal: true,
       });
     }
 

--- a/src/protocols/ethereum/components/TransferReview.vue
+++ b/src/protocols/ethereum/components/TransferReview.vue
@@ -41,7 +41,6 @@ import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import {
   useAccounts,
   useLatestTransactionList,
-  useModals,
   useUi,
 } from '@/composables';
 import { PROTOCOLS } from '@/constants';
@@ -50,6 +49,7 @@ import { ETH_COIN_SYMBOL } from '@/protocols/ethereum/config';
 import TransferReviewBase from '@/popup/components/TransferSend/TransferReviewBase.vue';
 import DetailsItem from '@/popup/components/DetailsItem.vue';
 import TokenAmount from '@/popup/components/TokenAmount.vue';
+import Logger from '@/lib/logger';
 
 export default defineComponent({
   name: 'EthTransferReview',
@@ -68,7 +68,6 @@ export default defineComponent({
     const { t } = useI18n();
     const router = useRouter();
     const { homeRouteName } = useUi();
-    const { openDefaultModal } = useModals();
     const { getLastActiveProtocolAccount } = useAccounts();
     const { addAccountPendingTransaction } = useLatestTransactionList();
 
@@ -81,10 +80,11 @@ export default defineComponent({
     );
 
     function openTransactionFailedModal(msg: string) {
-      openDefaultModal({
-        title: t('modals.transaction-failed.msg'),
-        icon: 'critical',
-        msg,
+      Logger.write({
+        title: t('modals.transaction-failed.title'),
+        message: msg || t('modals.transaction-failed.msg'),
+        type: 'api-response',
+        modal: true,
       });
     }
 
@@ -148,7 +148,7 @@ export default defineComponent({
         }
       } catch (error: any) {
         openTransactionFailedModal(error.message);
-        throw error;
+        return;
       } finally {
         loading.value = false;
       }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -50,6 +50,7 @@ import {
 } from '@/constants';
 import { tg } from '@/popup/plugins/i18n';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
+import { Directory, Filesystem } from '@capacitor/filesystem';
 import { decrypt, encrypt } from './crypto';
 
 /**
@@ -693,4 +694,29 @@ export function decryptedComputed(
       get: () => decrypted.value,
       set: setEncryptedState,
     });
+}
+
+export async function exportFile(
+  text: string,
+  filename: string,
+): Promise<string | undefined> {
+  const blob = new Blob([text], { type: 'text/plain' });
+
+  if (IS_MOBILE_APP) {
+    const base64 = await convertBlobToBase64(blob);
+    const saveFile = await Filesystem.writeFile({
+      path: filename,
+      data: base64,
+      directory: Directory.Documents,
+    });
+    return saveFile.uri;
+  }
+  const a = document.createElement('a');
+  const href = window.URL.createObjectURL(blob);
+
+  a.download = filename;
+  a.href = href;
+  a.dataset.downloadurl = ['text/json', a.download, a.href].join(':');
+  a.click();
+  return undefined;
 }


### PR DESCRIPTION
closes: #3039 

- Reusable export method for downloading files
- Changed wording in Error log Settings screen
- New modal to confirm disabling the logs
- Improved error logging on Transfers + Signing
- Error modal with Export button in the above cases
- Small UI fixes on buttons and inputs