### PR TITLE
fix: ios missing compliance

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -51,6 +51,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>  
+	<false/>
   <key>CFBundleURLTypes</key>
   <array>
     <dict>


### PR DESCRIPTION
- Added a new property in Info.plist to manage the encryption compliance in Testflight without the need to access AppStoreConnect on every build