### PR TITLE
Enrich token sale transactions information

### DIFF
--- a/src/composables/fungibleTokens.ts
+++ b/src/composables/fungibleTokens.ts
@@ -24,7 +24,7 @@ import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 
 import FungibleTokenFullInterfaceACI from '@/protocols/aeternity/aci/FungibleTokenFullInterfaceACI.json';
 import { AE_COIN_PRECISION } from '@/protocols/aeternity/config';
-import { aettosToAe, categorizeContractCallTxObject } from '@/protocols/aeternity/helpers';
+import { aettosToAe, categorizeContractCallTxObject, getTokenSaleBuyAmount } from '@/protocols/aeternity/helpers';
 
 import { useCurrencies } from './currencies';
 import { useAccounts } from './accounts';
@@ -264,6 +264,7 @@ export function useFungibleTokens() {
   function getTxAmountTotal(
     transaction: ITransaction,
     direction: string = TX_DIRECTION.sent,
+    isTokenSaleBuy: boolean = false,
   ) {
     const isReceived = direction === TX_DIRECTION.received;
     const { protocol, tx } = transaction || {};
@@ -294,7 +295,8 @@ export function useFungibleTokens() {
     const claimTipAmount = (tx.function === 'claim') ? tx.log?.[0]?.topics[2] : null;
 
     const rawAmount = (
-      tx?.amount
+      (isTokenSaleBuy && getTokenSaleBuyAmount(tx))
+      || tx?.amount
       || (tx?.tx?.tx as any)?.amount
       || tx?.nameFee
       || claimTipAmount

--- a/src/composables/transactionData.ts
+++ b/src/composables/transactionData.ts
@@ -71,6 +71,7 @@ export function useTransactionData({
     tokenBalances,
   } = useFungibleTokens();
   const {
+    tokenFactories,
     tokenSaleAddresses,
     tokenSaleAddressToTokenContractAddress,
   } = useAeTokenSales();
@@ -136,6 +137,11 @@ export function useTransactionData({
       isTokenSale.value
       && includes(TX_FUNCTIONS_TOKEN_SALE.sell, txFunctionRaw.value)
     ),
+  );
+
+  const isTokenSaleFactory = computed(
+    (): boolean => tokenFactories.value
+      .some(({ contractId }) => contractId === innerTx.value?.contractId),
   );
 
   const isDex = computed((): boolean => isTxDex(innerTx.value, dexContracts.value));
@@ -264,6 +270,7 @@ export function useTransactionData({
         && (
           isDex.value
           || isTokenSale.value
+          || isTokenSaleFactory.value
           || (isAllowance.value && showDetailedAllowanceInfo)
         )
       ) {
@@ -359,6 +366,7 @@ export function useTransactionData({
 
     isTokenSale,
     isTokenSaleBuy,
+    isTokenSaleFactory,
     isTokenSaleSell,
 
     isDex,

--- a/src/composables/transactionData.ts
+++ b/src/composables/transactionData.ts
@@ -229,7 +229,7 @@ export function useTransactionData({
    */
   const amountTotal = computed(
     (): number => (transaction.value)
-      ? getTxAmountTotal(transaction.value, direction.value)
+      ? getTxAmountTotal(transaction.value, direction.value, isTokenSaleBuy.value)
       : 0,
   );
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -133,6 +133,7 @@ export const STORAGE_KEYS = {
   permissions: 'permissions',
   appsBrowserHistory: 'apps-browser-history',
   tokenSales: 'token-sales',
+  tokenFactories: 'token-factories',
   transactionsLatest: 'transactions-latest',
   transactionsLoaded: 'transactions-loaded',
   transactionsPending: 'transactions-pending',

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -72,6 +72,12 @@
         />
       </template>
 
+      <DetailsItem
+        v-if="isTokenSaleFactory && tokenList.length"
+        :label="$t('transaction.tokenSale.tokenName')"
+        :value="tokenList[1]?.symbol"
+      />
+
       <div class="details">
         <DetailsItem
           v-if="nameAeFee"
@@ -84,7 +90,7 @@
         </DetailsItem>
 
         <DetailsItem
-          v-if="isDexSwap || isTokenSale"
+          v-if="isDexSwap || isTokenSale || isTokenSaleFactory"
           :label="swapDirectionTranslation"
         >
           <TokenAmount
@@ -143,7 +149,7 @@
         >
           <TokenAmount
             :amount="executionCost || amountTotal"
-            :symbol="isTokenSale ? undefined : tokenSymbol"
+            :symbol="isTokenSale || isTokenSaleFactory ? undefined : tokenSymbol"
             :hide-fiat="isAex9"
             :protocol="protocol"
             high-precision
@@ -352,6 +358,7 @@ export default defineComponent({
       isDexPool,
       isDexSwap,
       isTokenSale,
+      isTokenSaleFactory,
       txFunctionParsed,
       transactionAssets,
     } = useTransactionData({
@@ -437,14 +444,14 @@ export default defineComponent({
       : undefined);
 
     async function getTokens(txParams: ITx): Promise<ITokenResolved[]> {
-      if (!isDex.value && !isAllowance.value && !isTokenSale.value) {
+      if (!isDex.value && !isAllowance.value && !isTokenSale.value && !isTokenSaleFactory.value) {
         return [singleToken.value];
       }
       const resolver = getTransactionTokenInfoResolver(txFunctionParsed.value!);
       if (!resolver) {
         return [];
       }
-      if (protocol === PROTOCOLS.aeternity && isTokenSale.value) {
+      if (protocol === PROTOCOLS.aeternity && (isTokenSale.value || isTokenSaleFactory.value)) {
         // Wait until token sale tokens are resolved
         await watchUntilTruthy(areTokenSalesReady);
       }
@@ -453,7 +460,7 @@ export default defineComponent({
         getProtocolAvailableTokens(PROTOCOLS.aeternity),
         tokenSaleAddressToTokenContractAddress,
       )?.tokens;
-      if (!(isDexPool.value || isTokenSale.value)) {
+      if (!(isDexPool.value || isTokenSale.value || isTokenSaleFactory.value)) {
         return tokens;
       }
       if (isDexLiquidityAdd.value) {
@@ -665,6 +672,7 @@ export default defineComponent({
       isDexMinReceived,
       isDexSwap,
       isTokenSale,
+      isTokenSaleFactory,
       isHash,
       isUnknownDapp,
       loading,

--- a/src/popup/components/TransactionLabel.vue
+++ b/src/popup/components/TransactionLabel.vue
@@ -122,6 +122,7 @@ export default defineComponent({
       isDexLiquidityAdd,
       isDexLiquidityRemove,
       isTokenSaleBuy,
+      isTokenSaleFactory,
       isTokenSaleSell,
       isErrorTransaction,
       isTip,
@@ -171,6 +172,8 @@ export default defineComponent({
         text = t('transaction.tokenSale.bought');
       } else if (isTokenSaleSell.value) {
         text = t('transaction.tokenSale.sold');
+      } else if (isTokenSaleFactory.value) {
+        text = t('transaction.tokenSale.createdToken');
       } else if (isTip.value && props.transaction.claim) {
         text = t('transaction.listType.tipReceived');
       } else if (isTip.value) {

--- a/src/popup/components/TransactionTagList.vue
+++ b/src/popup/components/TransactionTagList.vue
@@ -62,6 +62,7 @@ export default defineComponent({
       isAllowance,
       isTokenSale,
       isTokenSaleBuy,
+      isTokenSaleFactory,
       isTokenSaleSell,
     } = useTransactionData({
       transaction: toRef(() => props.transaction),
@@ -130,6 +131,8 @@ export default defineComponent({
             ? t('common.sell')
             : '',
         );
+      } else if (isTokenSaleFactory.value) {
+        arr.push(t('transaction.tokenSale.createToken'));
       } else if (
         props.transaction.claim
         || (

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -590,6 +590,9 @@
     },
     "tokenSale": {
       "tag": "token sale",
+      "createToken": "Create Token",
+      "createdToken": "Created token",
+      "tokenName": "Token name",
       "bought": "Bought",
       "sold": "Sold"
     }

--- a/src/protocols/aeternity/config.ts
+++ b/src/protocols/aeternity/config.ts
@@ -139,6 +139,7 @@ export const TX_FUNCTIONS = {
   /** token sales */
   buy: 'buy',
   sell: 'sell',
+  createCommunity: 'create_community',
 } as const;
 
 /**

--- a/src/protocols/aeternity/config.ts
+++ b/src/protocols/aeternity/config.ts
@@ -248,7 +248,12 @@ export const DEX_CONTRACTS: Record<string, IDexContracts> = {
   },
 };
 
-export const AEX9_TRANSFER_EVENT = 'Aex9TransferEvent';
+export const ACTIVITIES_TYPES = {
+  aex9TransferEvent: 'Aex9TransferEvent',
+  contractCallTxEvent: 'ContractCallTxEvent',
+  internalContractCallEvent: 'InternalContractCallEvent',
+  internalTransferEvent: 'InternalTransferEvent',
+} as const;
 
 export const AE_TRANSACTION_OWNERSHIP_STATUS = {
   other: 0,

--- a/src/protocols/aeternity/helpers/index.ts
+++ b/src/protocols/aeternity/helpers/index.ts
@@ -39,6 +39,7 @@ import {
   isNotFoundError,
 } from '@/utils';
 import {
+  ACTIVITIES_TYPES,
   AE_AENS_DOMAIN,
   AE_CONTRACT_ID,
   AE_FAUCET_URL,
@@ -135,6 +136,17 @@ export function categorizeContractCallTxObject(transaction: ITransaction): {
     default:
       return null;
   }
+}
+
+export function getTokenSaleBuyAmount(tx: ITx) {
+  const refundEvent = tx?.internalEvents
+    ?.find(({ type }) => ACTIVITIES_TYPES.internalContractCallEvent === type);
+
+  return (
+    refundEvent && refundEvent.payload.internalTx.recipientId === tx.callerId
+  )
+    ? tx.amount - refundEvent.payload.internalTx.amount
+    : tx.amount;
 }
 
 /**

--- a/src/protocols/aeternity/helpers/transactionTokenInfoResolvers.ts
+++ b/src/protocols/aeternity/helpers/transactionTokenInfoResolvers.ts
@@ -436,6 +436,30 @@ const sell: TransactionResolver = (transaction, tokens = null, tokenAddressMappe
   };
 };
 
+const createCommunity: TransactionResolver = (
+  transaction,
+  tokens = null,
+) => {
+  const isConfirm = !transaction.tx.return;
+  const token = {
+    amount: transaction.tx.arguments?.[2]?.value,
+    ...defaultToken,
+    symbol: transaction.tx.arguments?.[1]?.value,
+    ...(isConfirm ? {} : tokens?.[transaction.tx.log?.[2]?.address]),
+    isReceived: true,
+  };
+  const aeToken = {
+    ...defaultToken,
+    assetType: ASSET_TYPES.coin,
+    protocol: PROTOCOLS.aeternity,
+    amount: transaction.tx.amount,
+    isReceived: false,
+  };
+  return {
+    tokens: [token, aeToken],
+  };
+};
+
 // TODO: refactor resolver to use internal events and be generic for every contract call,
 // instead of creating a unique resolver each time for the supported contracts
 
@@ -457,6 +481,7 @@ const resolvers: TransactionResolvers = {
   withdraw,
   buy,
   sell,
+  createCommunity,
 };
 
 export function getTransactionTokenInfoResolver(txFunctionName: TxFunctionParsed) {

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -275,6 +275,7 @@ export default defineComponent({
       isDexPool,
       isDexSwap,
       isTokenSale,
+      isTokenSaleBuy,
       outerTxTag,
       transactionAssets,
     } = useTransactionData({
@@ -296,10 +297,10 @@ export default defineComponent({
       : undefined);
 
     const amount = computed((): number => transaction.value
-      ? getTxAmountTotal(transaction.value, TX_DIRECTION.received)
+      ? getTxAmountTotal(transaction.value, TX_DIRECTION.received, isTokenSaleBuy.value)
       : 0);
     const amountTotal = computed((): number => transaction.value
-      ? getTxAmountTotal(transaction.value, direction.value)
+      ? getTxAmountTotal(transaction.value, direction.value, isTokenSaleBuy.value)
       : 0);
     const tipUrl = computed(() => transaction.value ? getTransactionTipUrl(transaction.value) : '');
     const tipLink = computed(() => /^http[s]*:\/\//.test(tipUrl.value) ? tipUrl.value : `http://${tipUrl.value}`);

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -16,6 +16,7 @@
               || isAllowance
               || isAex9
               || isTokenSale
+              || isTokenSaleFactory
             )"
             :hide-fiat="hideFiat"
             :hash="hash"
@@ -276,6 +277,7 @@ export default defineComponent({
       isDexSwap,
       isTokenSale,
       isTokenSaleBuy,
+      isTokenSaleFactory,
       outerTxTag,
       transactionAssets,
     } = useTransactionData({
@@ -418,6 +420,7 @@ export default defineComponent({
       isDexPool,
       isDexSwap,
       isTokenSale,
+      isTokenSaleFactory,
       getTransactionPayload,
       tipUrl,
       tipLink,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -514,6 +514,7 @@ export interface ITx {
   gasLimit?: number;
   gasPrice?: number;
   gasUsed?: number;
+  internalEvents?: any[]; // TODO: type internal events
   log?: any[]; // TODO find source
   name?: any;
   nameFee?: number;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -720,3 +720,13 @@ export async function exportFile(
   a.click();
   return undefined;
 }
+
+export function getActivityHash(activity: any) {
+  return (
+    activity?.payload?.txHash
+    ?? activity?.payload?.hash
+    ?? activity?.payload?.callTxHash
+    ?? activity?.payload?.refTxHash
+    ?? activity?.payload?.contractTxHash
+  );
+}


### PR DESCRIPTION
fixes #3387,
fixes #3460,
fixes #3464,
fixes #3465,
fixes #3417,
This PR is missing one particular case, if the user will refresh the Transaction Details for a `buy` token sale transaction, the info become less informative (and untruthful to spend amount and to received tokens/missing protocol token) .
After this issue will be resolved it will be easy from our side to fix that https://github.com/aeternity/ae_mdw/issues/2075