### PR TITLE
Adjust transaction list

### DIFF
--- a/src/popup/components/Tokens.vue
+++ b/src/popup/components/Tokens.vue
@@ -62,7 +62,7 @@ export default defineComponent({
      * Array of tokens that is returned by the transactionTokenInfoResolvers
      */
     tokens: { type: Array as PropType<ITokenResolved[]>, required: true },
-    symbolLength: { type: Number, default: 11 },
+    symbolLength: { type: Number, default: 10 },
     doubleSymbolLength: { type: Number, default: 5 },
     /**
      * TODO if protocol is not set, assume AE, but this should be set correctly

--- a/src/popup/components/TransactionAssetRows.vue
+++ b/src/popup/components/TransactionAssetRows.vue
@@ -131,6 +131,8 @@ export default defineComponent({
 
       .amount {
         @extend %face-sans-18-regular;
+
+        font-size: var(--font-size);
       }
     }
   }

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -190,6 +190,7 @@ import {
 import {
   useAccounts,
   useFungibleTokens,
+  useLatestTransactionList,
   useMultisigAccounts,
   useTransactionData,
   useTransactionList,
@@ -247,6 +248,7 @@ export default defineComponent({
     const { activeAccount, isLocalAccountAddress } = useAccounts();
     const { setLoaderVisible } = useUi();
     const { getTxAmountTotal, tokenBalances } = useFungibleTokens();
+    const { allLatestTransactions } = useLatestTransactionList();
 
     const hash = route.params.hash as string;
     const transactionOwner = route.params.transactionOwner as Encoded.AccountAddress;
@@ -342,7 +344,10 @@ export default defineComponent({
     });
 
     onMounted(async () => {
-      let rawTransaction: ITransaction | undefined = transactionsLoaded.value
+      let rawTransaction: ITransaction | undefined = [
+        ...transactionsLoaded.value,
+        ...allLatestTransactions.value,
+      ]
         .find((tx) => tx.hash === hash) as ITransaction;
 
       // Claim transactions have missing data that needs to be fetched from the middleware

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -90,7 +90,7 @@ export function calculateFontSize(amountValue: BigNumber | number | string) {
     return '16px';
   }
   if (amountLength <= 14) {
-    return '14px';
+    return '13px';
   }
   return '12px';
 }


### PR DESCRIPTION
- fixes #3406,
- fixes #2647,
- fixes issue when token sale transaction is in the latest transaction widget have full info, but clicking on leads you to the transaction details page with less info (not enriched info). 
- enriches `createCommunity` contact call info