### PR TITLE
feat: multiple recipients transaction

### DIFF
--- a/src/composables/accountSelector.ts
+++ b/src/composables/accountSelector.ts
@@ -140,16 +140,9 @@ export const useAccountSelector = createCustomScopedComposable(() => {
         return [];
     }
   });
-  const accountsFiltered = computed(() => {
-    const entries: IAccountSelectorEntry[] = accountsFilteredByType.value ?? [];
-    const searchQueryLower = searchQuery.value.toLowerCase();
-
+  function transformAccounts(entries: IAccountSelectorEntry[]) {
     return entries
-      .filter( // Filter by searchQuery
-        ({ name, address }) => [name, address].some(
-          (val) => val.toLowerCase().includes(searchQueryLower),
-        ),
-      ).filter( // Remove duplicates
+      .filter( // Remove duplicates
         (entry, index, self) => self.findIndex(
           (e) => (
             (e.address !== undefined && e.address === entry.address)
@@ -164,7 +157,24 @@ export const useAccountSelector = createCustomScopedComposable(() => {
           ),
         }),
       );
+  }
+  const accountsFiltered = computed(() => {
+    const entries: IAccountSelectorEntry[] = accountsFilteredByType.value ?? [];
+    const searchQueryLower = searchQuery.value.toLowerCase();
+
+    return transformAccounts(entries
+      .filter( // Filter by searchQuery
+        ({ name, address }) => [name, address].some(
+          (val) => val.toLowerCase().includes(searchQueryLower),
+        ),
+      ));
   });
+  const allAccounts = computed(() => (
+    transformAccounts([
+      ...addressBookFiltered.value,
+      ...ownAddresses.value,
+      ...latestTransactions.value,
+    ])));
 
   function setAccountSelectType(type: AccountSelectTypeFilter, resetProtocolFilter = false) {
     accountSelectType.value = type;
@@ -201,6 +211,7 @@ export const useAccountSelector = createCustomScopedComposable(() => {
   return {
     accountSelectType,
     accountsFiltered,
+    allAccounts,
     addressBookFilteredByProtocol,
     protocolFilter,
     showBookmarked,

--- a/src/composables/transferSendForm.ts
+++ b/src/composables/transferSendForm.ts
@@ -45,7 +45,7 @@ export function useTransferSendForm({
   const { accountAssets } = useAccountAssetsList();
 
   const hasError = computed(
-    (): boolean => ['address', 'amount'].some(
+    (): boolean => ['addresses', 'amount'].some(
       (errorKey) => getMessageByFieldName(errors.value[errorKey]).status === 'error',
     ),
   );
@@ -75,7 +75,7 @@ export function useTransferSendForm({
       result.selectedAsset = selectedToken;
     }
     if (account) {
-      result.address = account;
+      result.addresses = [account, ...(formModel.value.addresses ?? [])];
     }
     if (amount) {
       result.amount = amount;
@@ -120,7 +120,7 @@ export function useTransferSendForm({
         if (!IS_PRODUCTION) {
           Logger.write(error);
         }
-        formModel.value.address = undefined;
+        formModel.value.addresses = undefined;
         openDefaultModal({
           title: t('modals.invalid-qr-code.msg'),
           icon: 'critical',
@@ -132,7 +132,7 @@ export function useTransferSendForm({
       const requestedTokenBalance = accountAssets.value
         .find(({ contractId }) => contractId === parsedScanResult.tokenContract);
       if (!requestedTokenBalance) {
-        formModel.value.address = undefined;
+        formModel.value.addresses = undefined;
         openDefaultModal({ msg: t('modals.insufficient-balance.msg') });
         return;
       }
@@ -141,7 +141,7 @@ export function useTransferSendForm({
       formModel.value.selectedAsset = requestedTokenBalance;
 
       // SET result data
-      formModel.value.address = parsedScanResult.tokenContract;
+      formModel.value.addresses = [parsedScanResult.tokenContract];
       formModel.value.amount = toShiftedBigNumber(
         parsedScanResult.amount,
         -(formModel.value.selectedAsset?.decimals || -0),
@@ -163,8 +163,8 @@ export function useTransferSendForm({
       ].map(([k, v]) => [k, v])));
       invoiceId.value = null;
     }
-    if (!formModel.value.address) {
-      formModel.value.address = undefined;
+    if (!formModel.value.addresses) {
+      formModel.value.addresses = undefined;
     }
   }
 

--- a/src/popup/components/DetailsItem.vue
+++ b/src/popup/components/DetailsItem.vue
@@ -12,7 +12,7 @@
       class="text-label label"
       @click="toggleExpanded()"
     >
-      {{ label }}
+      {{ expanded && expandedLabel ? expandedLabel : label }}
       <span
         v-if="$slots.label"
         :class="{ indent: label }"
@@ -59,6 +59,7 @@ export default defineComponent({
   },
   props: {
     label: { type: String, default: '' },
+    expandedLabel: { type: String, default: '' },
     value: { type: [String, Number, Array], default: '' },
     secondary: { type: String, default: '' },
     expandable: Boolean,
@@ -93,7 +94,7 @@ export default defineComponent({
   .label {
     display: flex;
     align-items: center;
-    margin-bottom: 4px;
+    margin-bottom: 8px;
 
     .indent {
       margin-left: 8px;

--- a/src/popup/components/InputField.vue
+++ b/src/popup/components/InputField.vue
@@ -54,7 +54,7 @@
       <slot
         name="before-main"
       />
-      <div class="main-inner">
+      <div class="main-inner styled-scrollbar">
         <slot
           v-if="!hasError && !hasWarning"
           name="before"
@@ -110,7 +110,7 @@
         class="message-text"
         data-cy="input-field-message"
         :for="inputId"
-        v-text="(messageAsObject) ? messageAsObject.text : null"
+        v-text="(messageAsObject) ? messageAsObject.text?.split('||')[0] : null"
       />
     </div>
   </div>
@@ -376,8 +376,8 @@ export default defineComponent({
     .main-inner {
       display: flex;
       align-items: center;
-      width: 100%;
       gap: 6px;
+      width: 100%;
 
       :deep(.icon) {
         width: var(--size, 24px);

--- a/src/popup/components/Modals/AddressBookAccountSelector.vue
+++ b/src/popup/components/Modals/AddressBookAccountSelector.vue
@@ -4,7 +4,7 @@
     has-close-button
     full-screen
     from-bottom
-    @close="resolve"
+    @close="cancel()"
   >
     <IonPage>
       <h2
@@ -13,11 +13,44 @@
           isSigner ? $t('pages.addressBook.selectSignerAddress') : $t('pages.addressBook.selectRecipientAddress')
         )"
       />
+      <div
+        v-if="allowMultiple"
+        class="tabs-container"
+      >
+        <Tabs class="tabs">
+          <Tab
+            v-for="({ name, text }) in dataTabs"
+            :key="name"
+            :data-cy="name"
+            :text="text"
+            :active="activeTab === name"
+            @click="setActiveTab(name)"
+          />
+        </Tabs>
+      </div>
       <AddressBookList
         is-selector
-        @select-address="handleSelectAddress"
+        :selected-addresses="selectedAddresses"
+        :is-multiple="activeTab === dataTabs[1].name"
+        @select-address="handleSelectAddresses"
       />
     </IonPage>
+    <template v-if="activeTab === dataTabs[1].name" #footer>
+      <BtnMain
+        variant="muted"
+        class="button-action-secondary"
+        data-cy="cancel"
+        :text="$t('common.cancel')"
+        @click="cancel()"
+      />
+      <BtnMain
+        class="button-action-primary"
+        data-cy="submit"
+        :text="`${$t('pages.addressBook.useSelected')} (${selectedAddresses.length})`"
+        :disabled="!selectedAddresses.length"
+        @click="submit()"
+      />
+    </template>
   </Modal>
 </template>
 
@@ -25,9 +58,10 @@
 import {
   defineComponent,
   onBeforeMount,
-  onUnmounted,
   PropType,
+  ref,
 } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { IonPage } from '@ionic/vue';
 
 import type { ResolveCallback, RejectCallback, Protocol } from '@/types';
@@ -35,37 +69,89 @@ import { useAccounts, useAddressBook } from '@/composables';
 
 import Modal from '@/popup/components/Modal.vue';
 import AddressBookList from '@/popup/components/AddressBook/AddressBookList.vue';
+import BtnMain from '@/popup/components/buttons/BtnMain.vue';
+import Tabs from '@/popup/components/tabs/Tabs.vue';
+import Tab from '@/popup/components/tabs/Tab.vue';
 
 export default defineComponent({
   components: {
     IonPage,
     Modal,
     AddressBookList,
+    BtnMain,
+    Tabs,
+    Tab,
   },
   props: {
     resolve: { type: Function as PropType<ResolveCallback>, required: true },
     reject: { type: Function as PropType<RejectCallback>, required: true },
     protocol: { type: String as PropType<Protocol>, default: null },
     isSigner: Boolean,
+    allowMultiple: Boolean,
+    preSelectedAddresses: {
+      type: Array as PropType<string[]>,
+      default: () => [],
+    },
   },
   setup(props) {
+    const { t } = useI18n();
     const { activeAccount } = useAccounts();
     const { setProtocolFilter } = useAddressBook();
 
-    function handleSelectAddress(address: string) {
-      props.resolve(address);
+    const preSelectedAddresses = [...props.preSelectedAddresses];
+    const selectedAddresses = ref<string[]>(props.preSelectedAddresses);
+
+    const dataTabs = [
+      {
+        name: 'single',
+        text: t('pages.addressBook.singleRecipient'),
+      },
+      {
+        name: 'multiple',
+        text: t('pages.addressBook.multipleRecipients'),
+      },
+    ];
+    const activeTab = ref(dataTabs[props.preSelectedAddresses?.length > 1 ? 1 : 0].name);
+
+    function handleSelectAddresses(address: string) {
+      if (activeTab.value === dataTabs[0].name) {
+        props.resolve([address]);
+        return;
+      }
+      const index = selectedAddresses.value.indexOf(address);
+
+      if (index !== -1) {
+        // Remove it if it's already selected
+        selectedAddresses.value.splice(index, 1);
+      } else {
+        selectedAddresses.value.push(address);
+      }
+    }
+
+    function setActiveTab(tabName: string) {
+      activeTab.value = tabName;
+    }
+
+    function submit() {
+      props.resolve(selectedAddresses.value);
+    }
+
+    function cancel() {
+      props.resolve(preSelectedAddresses);
     }
 
     onBeforeMount(() => {
       setProtocolFilter(props.protocol ?? activeAccount.value?.protocol);
     });
 
-    onUnmounted(() => {
-      setProtocolFilter(null);
-    });
-
     return {
-      handleSelectAddress,
+      dataTabs,
+      activeTab,
+      selectedAddresses,
+      setActiveTab,
+      handleSelectAddresses,
+      submit,
+      cancel,
     };
   },
 });
@@ -81,6 +167,10 @@ export default defineComponent({
 
     padding: 8px 16px;
     color: rgba($color-white, 0.75);
+  }
+
+  .tabs-container {
+    padding: 0px 8px;
   }
 }
 </style>

--- a/src/popup/components/Modals/MultisigVaultCreate.vue
+++ b/src/popup/components/Modals/MultisigVaultCreate.vue
@@ -34,7 +34,6 @@
         <Field
           v-else
           v-slot="{ field, errorMessage }"
-          v-model="signer.address"
           :name="`signer-address-${index}`"
           :rules="{
             required: true,
@@ -43,8 +42,9 @@
         >
           <FormAccountInput
             v-bind="field"
-            :model-value="signer.address"
+            :model-value="signer.address ? [signer.address] : undefined"
             hide-clear-icon
+            single-default-format
             :label="getSignerLabel(index)"
             :placeholder="$t('modals.createMultisigAccount.signerInputPlaceholder')"
             :name="`signer-address-${index}`"
@@ -52,6 +52,8 @@
             :class="{
               error: checkIfSignerAddressDuplicated(signer),
             }"
+            :protocol="PROTOCOLS.aeternity"
+            @update:modelValue="($event) => updateSigner(index, $event[0])"
           >
             <template #label-after>
               <div class="buttons">
@@ -78,7 +80,7 @@
                 @click="removeSigner(index)"
               />
               <BtnIcon
-                v-if="signer.address?.length > 0"
+                v-if="signer.address?.length! > 0"
                 :icon="CircleCloseIcon"
                 data-cy="clear-address-button"
                 class="close-icon"
@@ -359,12 +361,12 @@ export default defineComponent({
     }
 
     async function updateSignerFromAddressBook(index: number) {
-      const address = await openModal<Encoded.AccountAddress>(
+      const addresses = await openModal<Encoded.AccountAddress[]>(
         MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR,
         { protocol: PROTOCOLS.aeternity, isSigner: true },
       );
-      if (address) {
-        updateSigner(index, address);
+      if (addresses) {
+        updateSigner(index, addresses[0]);
       }
     }
 
@@ -492,6 +494,7 @@ export default defineComponent({
       scanSignerAccountQrCode,
       addNewSigner,
       removeSigner,
+      updateSigner,
       clearSigner,
       getSignerLabel,
       navigateToMultisigVault,

--- a/src/popup/components/Modals/RecipientInfo.vue
+++ b/src/popup/components/Modals/RecipientInfo.vue
@@ -20,7 +20,7 @@
               v-if="isProtocolAe"
               class="title"
             >
-              {{ $t('modals.recipient.msg.publicAddress.title') }}
+              {{ $t('modals.recipient.msg.publicAddress.title') }}:
             </strong>
           </i18n-t>
         </p>
@@ -35,6 +35,17 @@
               {{ $t('modals.recipient.msg.chain.title') }}:
             </strong>
             {{ $t('modals.recipient.msg.chain.linkTitle') }}
+          </i18n-t>
+        </p>
+        <p>
+          <i18n-t
+            keypath="modals.recipient.msg.multiple.msg"
+            tag="div"
+            scope="global"
+          >
+            <strong class="title">
+              {{ $t('modals.recipient.msg.multiple.title') }}:
+            </strong>
           </i18n-t>
         </p>
       </div>

--- a/src/popup/components/TransferQRCodeGenerator.vue
+++ b/src/popup/components/TransferQRCodeGenerator.vue
@@ -80,11 +80,14 @@ export default defineComponent({
       const aeSdk = await getAeSdk();
       const {
         amount: amountRaw,
-        address: recipient,
+        addresses: recipients,
         selectedAsset,
       } = props.transferData;
 
-      if (!amountRaw || !recipient || !selectedAsset || !isActiveAccountAirGap.value) {
+      if (!amountRaw
+        || !recipients?.length
+        || !selectedAsset
+        || !isActiveAccountAirGap.value) {
         return null;
       }
 
@@ -95,7 +98,7 @@ export default defineComponent({
       const txRaw = await aeSdk.buildTx({
         tag: Tag.SpendTx,
         senderId: activeAccount.value.address as Encoded.AccountAddress,
-        recipientId: recipient,
+        recipientId: recipients[0],
         amount: new BigNumber(amount).toFixed().toString(),
         payload: encode(new TextEncoder().encode(props.transferData.payload), Encoding.Bytearray),
       });

--- a/src/popup/components/TransferSend/TransferReviewBase.vue
+++ b/src/popup/components/TransferSend/TransferReviewBase.vue
@@ -16,6 +16,7 @@
 
     <DetailsItem
       :label="senderLabel"
+      class="sending-address"
       data-cy="review-sender"
     >
       <template #value>
@@ -23,6 +24,7 @@
           :address="activeAccount.address"
           :name="activeAccount.name"
           :show-address="!isRecipientName"
+          :protocol="protocol"
         />
       </template>
     </DetailsItem>
@@ -33,16 +35,25 @@
 
     <DetailsItem
       v-else
-      class="details-item"
+      class="details-item receiving-addresses"
       data-cy="review-recipient"
-      :label="$t('pages.send.recipient')"
+      expandable
+      :label="`${$t('pages.send.show')} ${transferData.addresses?.length} ${$t('pages.send.recipients')}`"
+      :expanded-label="`${$t('pages.send.hide')} ${transferData.addresses?.length} ${$t('pages.send.recipients')}`"
     >
       <template #value>
-        <AvatarWithChainName
-          :address="transferData.address"
-          :name="avatarName"
-          :show-address="!avatarName"
-        />
+        <div
+          v-for="address in transferData.addresses"
+          :key="address"
+          class="receiving-address"
+        >
+          <AvatarWithChainName
+            :address="address"
+            :name="isNameValid(address) ? address : undefined"
+            :show-address="!isNameValid(address)"
+            :protocol="protocol"
+          />
+        </div>
       </template>
     </DetailsItem>
 
@@ -62,6 +73,23 @@
       </template>
     </DetailsItem>
 
+    <DetailsItem
+      v-if="recipientsCount > 1"
+      :label="multipleAmountLabel"
+      class="details-item"
+    >
+      <template #value>
+        <TokenAmount
+          :amount="multipleAmount"
+          :symbol="tokenSymbol"
+          :protocol="protocol"
+          :hide-fiat="!showFiat"
+          :price="transferData.selectedAsset?.price"
+          data-cy="review-amount"
+        />
+      </template>
+    </DetailsItem>
+
     <slot name="additional-fee" />
 
     <DetailsItem
@@ -70,7 +98,7 @@
     >
       <template #value>
         <TokenAmount
-          :amount="+transferData.fee.toFixed()"
+          :amount="+transferData.fee"
           :symbol="baseTokenSymbol"
           :protocol="protocol"
           high-precision
@@ -125,12 +153,12 @@ export default defineComponent({
     subtitle: { type: String, default: tg('pages.send.checkalert') },
     senderLabel: { type: String, default: tg('pages.send.sender') },
     amountLabel: { type: String, default: tg('common.amount') },
+    multipleAmountLabel: { type: String, default: tg('pages.send.multipleAccountLabel') },
     feeLabel: { type: String, default: tg('transaction.fee') },
     baseTokenSymbol: { type: String, required: true },
     transferData: { type: Object as PropType<TransferFormModel>, required: true },
     protocol: { type: String as PropType<Protocol>, required: true },
     recipientAddress: { type: String, default: null },
-    avatarName: { type: String, default: null },
     noHeaderPadding: Boolean,
     withoutSubtitle: Boolean,
     loading: Boolean,
@@ -144,21 +172,65 @@ export default defineComponent({
     );
 
     const tokenSymbol = computed(() => props.transferData.selectedAsset?.symbol || '-');
+    const recipientsCount = computed(() => (props.transferData.addresses?.length || 1));
+    const multipleAmount = computed(() => (
+      recipientsCount.value > 1 && props.transferData.amount
+        ? +props.transferData.amount * recipientsCount.value
+        : 0
+    ));
 
     return {
       AE_CONTRACT_ID,
       isRecipientName,
       tokenSymbol,
       activeAccount,
+      recipientsCount,
+      multipleAmount,
+      isNameValid,
     };
   },
 });
 </script>
 
 <style scoped lang="scss">
+@use '@/styles/variables' as *;
+
 .transfer-review-base {
+  .sending-address {
+    :deep(.value) {
+      border-radius: 10px;
+      overflow: hidden;
+    }
+  }
+
   .details-item {
     margin-top: 16px;
+
+    &.receiving-addresses {
+      border-radius: 10px;
+      overflow: hidden;
+
+      .receiving-address {
+        width: 100%;
+        border-radius: 2px;
+        background-color: $color-border;
+      }
+
+      :deep(.label) {
+        width: 100%;
+        justify-content: space-between;
+        padding: 10px 8px;
+        margin: 0;
+        background-color: $color-border;
+      }
+
+      :deep(.value) {
+        margin: 4px 0px 0px 0px;
+        padding: 0;
+        border: 0;
+        background: none;
+      }
+    }
   }
 }
 </style>

--- a/src/popup/components/TransferSend/TransferSendRecipient.vue
+++ b/src/popup/components/TransferSend/TransferSendRecipient.vue
@@ -1,50 +1,38 @@
 <template>
   <div class="transfer-send-recipient">
-    <Field
-      v-slot="{ field }"
-      name="address"
+    <FormAccountInput
+      :v-model="modelValue"
       :model-value="modelValue"
-      :validate-on-mount="!!modelValue"
-      :rules="{
-        required: true,
-        address_not_same_as: [activeAccount.address, protocol],
-        ...validationRules,
-      }"
+      name="addresses"
+      data-cy="address"
+      show-help
+      show-message-help
+      is-recipient
+      :single-default-format="isUrlTippingEnabled"
+      :protocol="protocol"
+      :label="$t('modals.send.recipientLabel')"
+      :placeholder="placeholder"
+      :message="addressMessage"
+      @update:modelValue="$emit('update:modelValue', $event)"
+      @help="showRecipientHelp()"
     >
-      <FormAccountInput
-        v-bind="field"
-        :model-value="modelValue"
-        name="address"
-        data-cy="address"
-        show-help
-        show-message-help
-        :protocol="protocol"
-        :label="$t('modals.send.recipientLabel')"
-        :placeholder="placeholder"
-        :message="addressMessage"
-        @update:modelValue="$emit('update:modelValue', $event)"
-        @help="showRecipientHelp()"
-      >
-        <template #label-after>
-          <div class="buttons">
-            <BtnIcon
-              :icon="AddressBookIcon"
-              data-cy="address-book-button"
-              @click="selectFromAddressBook()"
-            />
-            <BtnIcon
-              :icon="QrScanIcon"
-              data-cy="scan-button"
-              @click="$emit('openQrModal')"
-            />
-          </div>
-        </template>
-      </FormAccountInput>
-    </Field>
-    <div
-      v-if="isTipUrl"
-      class="status"
-    >
+      <template #label-after>
+        <div class="buttons">
+          <BtnIcon
+            :icon="AddressBookIcon"
+            data-cy="address-book-button"
+            @click="selectFromAddressBook()"
+          />
+          <BtnIcon
+            :icon="QrScanIcon"
+            data-cy="scan-button"
+            @click="$emit('openQrModal')"
+          />
+        </div>
+      </template>
+    </FormAccountInput>
+
+    <div v-if="isTipUrl" class="status">
       <UrlStatus :status="urlStatus" />
     </div>
   </div>
@@ -55,8 +43,9 @@ import {
   computed,
   defineComponent,
   PropType,
+  watch,
 } from 'vue';
-import { Field } from 'vee-validate';
+import { useField } from 'vee-validate';
 
 import type { Protocol, IInputMessage } from '@/types';
 import { getMessageByFieldName } from '@/utils';
@@ -79,12 +68,13 @@ export default defineComponent({
   components: {
     FormAccountInput,
     UrlStatus,
-    Field,
     BtnIcon,
   },
   props: {
+    isUrlTippingEnabled: Boolean,
     isTipUrl: Boolean,
-    modelValue: { type: String, default: '' },
+    maxRecipients: { type: Number, default: null },
+    modelValue: { type: Array as PropType<string[]>, default: () => [] },
     placeholder: { type: String, default: '' },
     protocol: { type: String as PropType<Protocol>, required: true },
     validationRules: { type: Object, default: () => ({}) },
@@ -96,11 +86,25 @@ export default defineComponent({
 
     const { openModal } = useModals();
     const { activeAccount } = useAccounts();
+    const { value: fieldValue } = useField('addresses', {
+      required: true,
+      // TODO: currently it only shows the first warning/error, so give priority to error
+      ...(props.maxRecipients ? { max_recipients: props.maxRecipients } : {}),
+      ...props.validationRules,
+      address_not_same_as: [activeAccount.value.address, props.protocol],
+    }, {
+      bails: false, // TODO: validate all rules and show them all instead of the first
+    });
+
     const { getTippingUrlStatus } = useAeTippingUrls({ ensureFetchedOnInit: isAe.value });
 
-    const urlStatus = computed(() => getTippingUrlStatus(props.modelValue));
+    const urlStatus = computed(() => getTippingUrlStatus(props.modelValue?.[0]));
 
     const addressMessage = computed((): IInputMessage => {
+      const messagesByFieldName = getMessageByFieldName(props.errors.addresses);
+      if (messagesByFieldName.status === 'error') {
+        return messagesByFieldName;
+      }
       if (props.isTipUrl) {
         switch (urlStatus.value) {
           case 'verified':
@@ -114,7 +118,7 @@ export default defineComponent({
             throw new Error(`Unknown url status: ${urlStatus.value}`);
         }
       }
-      return getMessageByFieldName(props.errors.address);
+      return messagesByFieldName;
     });
 
     function showRecipientHelp() {
@@ -122,11 +126,27 @@ export default defineComponent({
     }
 
     async function selectFromAddressBook() {
-      const address = await openModal<string>(MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR);
-      if (address) {
-        emit('update:modelValue', address);
+      const addresses = await openModal<string[]>(
+        MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR,
+        {
+          preSelectedAddresses: props.modelValue,
+          allowMultiple: props.maxRecipients > 1,
+        },
+      );
+      if (addresses) {
+        // This includes all addresses, even if the user has typed them,
+        // since we are passing the preSelectedAddresses as a prop
+        emit('update:modelValue', [...addresses]);
       }
     }
+
+    watch(
+      () => props.modelValue,
+      (val) => {
+        fieldValue.value = val;
+      }, // validate on mount
+      { immediate: !!props.modelValue.length },
+    );
 
     return {
       QrScanIcon,

--- a/src/popup/components/form/FormAccountInput.vue
+++ b/src/popup/components/form/FormAccountInput.vue
@@ -2,34 +2,62 @@
   <FormTextarea
     :readonly="readonly"
     :text-limit="textLimit"
-    :model-value="modelValue"
-    :hide-error="isDropdownOpen"
+    :model-value="inputValue"
     :resizable="false"
     :placeholder="placeholder"
-    :disable-label-focus="!!selectedAddress"
+    :message="message"
     auto-height
-    @update:modelValue="$emit('update:modelValue', $event)"
+    enter-submit
+    @update:modelValue="($event: any) => inputValue = $event"
+    @submit="handleEnter"
   >
-    <template v-if="selectedAddress" #default>
-      <Truncate
-        :str="selectedAddress.name"
-        class="truncated-text"
-      />
-      <AddressTruncated
-        :address="selectedAddress.address"
-        :protocol="protocol"
-      />
-    </template>
-
-    <template v-if="selectedAddress" #after>
+    <template #after>
       <BtnIcon
-        v-if="!hideClearIcon"
+        v-if="!hideClearIcon && (selectedAddresses.length || inputValue.length)"
         :icon="CircleCloseIcon"
         data-cy="clear-address-button"
         class="close-icon"
         size="sm"
-        @click="clearAddress"
+        @click="clearAll"
       />
+    </template>
+    <template
+      v-if="selectedAddresses.length > 1 || (!singleDefaultFormat && selectedAddresses.length)"
+      #under
+    >
+      <div class="selected-addresses-container styled-scrollbar">
+        <div
+          v-for="(account, idx) in selectedAddresses"
+          :key="idx"
+          class="selected-address-container"
+        >
+          <Truncate
+            class="truncated-text"
+            :class="{
+              error: (hasError && messageAsObject?.text?.includes(account.address)),
+              warning: (hasWarning && messageAsObject?.text?.includes(account.address)),
+            }"
+            :str="account.name"
+          />
+          <AddressTruncated
+            v-if="!isNameValid(account.address) && isAccountAddressValid(account.address)"
+            :address="account.address"
+            :protocol="protocol"
+            :class="{
+              error: (hasError && messageAsObject?.text?.includes(account.address)),
+              warning: (hasWarning && messageAsObject?.text?.includes(account.address)),
+            }"
+          />
+          <BtnIcon
+            v-if="!hideClearIcon"
+            :icon="TrashIcon"
+            data-cy="clear-address-button"
+            class="close-icon"
+            size="sm"
+            @click="clearAddress(idx)"
+          />
+        </div>
+      </div>
     </template>
 
     <template
@@ -81,9 +109,16 @@ import {
   ref,
   watch,
 } from 'vue';
+import { useI18n } from 'vue-i18n';
 
-import type { IAddressBookEntry, Protocol } from '@/types';
-import { useAddressBook } from '@/composables';
+import type {
+  IAddressBookEntry, IInputMessage, IInputMessageRaw, Protocol,
+} from '@/types';
+import { INPUT_MESSAGE_STATUSES } from '@/constants';
+import { useAddressBook, useNetworks, useAccountSelector } from '@/composables';
+import { excludeFalsy, removeDuplicates } from '@/utils';
+import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
+import { isNameValid } from '@aeternity/aepp-sdk';
 
 import Avatar from '@/popup/components/Avatar.vue';
 import AddressTruncated from '@/popup/components/AddressTruncated.vue';
@@ -92,6 +127,7 @@ import FormTextarea from '@/popup/components/form/FormTextarea.vue';
 
 import BtnIcon from '@/popup/components/buttons/BtnIcon.vue';
 import CircleCloseIcon from '@/icons/circle-close.svg?vue-component';
+import TrashIcon from '@/icons/trash.svg?vue-component';
 
 const SIZES = ['xxs', 'xs', 'sm', 'rg', 'md'];
 
@@ -105,7 +141,7 @@ export default defineComponent({
   },
   props: {
     type: { type: String, default: '' },
-    modelValue: { type: String, default: '' },
+    modelValue: { type: Array as PropType<string[]>, default: () => [] },
     placeholder: { type: String, default: '' },
     textLimit: { type: Number, default: null },
     resizable: { type: Boolean, default: true },
@@ -118,62 +154,176 @@ export default defineComponent({
       type: Array,
       default: () => [],
     },
-    enterSubmit: Boolean,
+    message: {
+      type: [String, Object] as PropType<IInputMessageRaw>,
+      validator: (value: IInputMessageRaw) => {
+        if (typeof value === 'object' && value.status) {
+          return !!INPUT_MESSAGE_STATUSES[value.status];
+        }
+        return true;
+      },
+      default: null,
+    },
     readonly: Boolean,
     hideClearIcon: Boolean,
+    singleDefaultFormat: Boolean,
     protocol: { type: String as PropType<Protocol>, default: null },
   },
   emits: ['update:modelValue', 'submit'],
   setup(props, { emit }) {
+    const { activeNetwork } = useNetworks();
     const {
       addressBookFiltered,
       protocolFilter,
     } = useAddressBook();
+    const { allAccounts } = useAccountSelector();
+    const { t } = useI18n();
     protocolFilter.value = props.protocol;
 
+    const inputValue = ref(props.singleDefaultFormat ? (props.modelValue[0] ?? '') : '');
     const isDropdownOpen = ref(false);
-    const selectedAddress = ref<IAddressBookEntry | undefined>();
+    const selectedAddresses = ref<IAddressBookEntry[]>([]);
     const filteredOptions = computed(() => (
       addressBookFiltered.value.filter((entry: IAddressBookEntry) => (
-        entry.address.toLowerCase().includes(props.modelValue.toString().toLowerCase())
-            || entry.name.toLowerCase().includes(props.modelValue.toString().toLowerCase())
+        (entry.address.toLowerCase().includes(inputValue.value.toLowerCase())
+            || entry.name.toLowerCase().includes(inputValue.value.toLowerCase()))
+            && (
+              !selectedAddresses.value.map((account) => account.address)
+                .includes(entry.address)
+              || !selectedAddresses.value.map((account) => account.name)
+                .includes(entry.name)
+            )
       ))
     ));
+    const messageAsObject = computed(
+      (): IInputMessage | null => (typeof props.message === 'object') ? props.message : { text: props.message },
+    );
+    const hasError = computed(
+      () => (
+        messageAsObject.value?.status === INPUT_MESSAGE_STATUSES.error
+        || !!messageAsObject.value?.text
+      ),
+    );
+    const hasWarning = computed(
+      () => (messageAsObject.value?.status === INPUT_MESSAGE_STATUSES.warning),
+    );
 
-    function clearAddress() {
-      selectedAddress.value = undefined;
-      emit('update:modelValue', '');
+    function clearAddress(idx: number) {
+      selectedAddresses.value.splice(idx, 1);
+      emit('update:modelValue', selectedAddresses.value.map((account) => account.address));
+    }
+
+    function clearAll() {
+      inputValue.value = '';
+      selectedAddresses.value = [];
+      emit('update:modelValue', []);
     }
 
     function selectValue(entry: IAddressBookEntry, $event: Event) {
       $event.preventDefault();
-      emit('update:modelValue', entry?.address);
+      if (props.singleDefaultFormat) {
+        inputValue.value = entry.address;
+      } else {
+        inputValue.value = '';
+        emit('update:modelValue', [entry.address, ...props.modelValue]);
+      }
       isDropdownOpen.value = false;
     }
 
-    onMounted(() => {
-      watch(() => props.modelValue, () => {
-        selectedAddress.value = (props.modelValue)
-          ? addressBookFiltered.value?.find((entry) => (entry.address === props.modelValue))
-          : undefined; // If it's cleared externally
+    function isAccountAddressValid(value: string) {
+      return ProtocolAdapterFactory
+        .getAdapter(props.protocol)
+        .isAccountAddressValid(value, activeNetwork.value?.type);
+    }
 
-        isDropdownOpen.value = props.modelValue.toString().length >= 2
-            && filteredOptions.value.length > 0;
-        if (addressBookFiltered.value?.find(
-          (entry) => (entry.address === props.modelValue.toString()),
-        )) {
-          isDropdownOpen.value = false;
+    function handleEnter() {
+      inputValue.value += ',';
+    }
+
+    onMounted(() => {
+      watch(() => [props.modelValue, allAccounts.value], () => {
+        // Check and remove duplicates
+        if (new Set(props.modelValue).size !== props.modelValue.length) {
+          emit('update:modelValue', props.modelValue.filter(removeDuplicates));
+        } else if (props.modelValue.length > 0) {
+          selectedAddresses.value = props.modelValue
+            .filter(excludeFalsy)
+            .map((address) => {
+              const existingAccount = allAccounts.value.find((account) => (
+                account.address === address
+              ));
+
+              let name = address;
+              if (isNameValid(address)) {
+                name = address;
+              } else if (isAccountAddressValid(address)) {
+                name = t('modals.send.recipientLabel');
+              }
+
+              return existingAccount || {
+                name,
+                address,
+                isBookmarked: false,
+                protocol: props.protocol,
+              };
+            }) || [];
+          if (selectedAddresses.value.length === 1 && props.singleDefaultFormat) {
+            inputValue.value = selectedAddresses.value[0].address;
+          }
+        } else {
+          inputValue.value = '';
+          selectedAddresses.value = [];
         }
       }, { immediate: true });
+
+      watch(inputValue, () => {
+        isDropdownOpen.value = inputValue.value.length >= 2
+          && filteredOptions.value.length > 0;
+        if (props.singleDefaultFormat) {
+          emit('update:modelValue', [inputValue.value]);
+          return;
+        }
+        if (inputValue.value.length) {
+          const values = inputValue.value.split(',').map((address: string) => address.trim());
+          let parsedValues: string[] = [];
+          // If the user has added multiple values (through copy paste), just append everything
+          if (values.length > 1) {
+            parsedValues = values.filter(excludeFalsy);
+          } else {
+            // Otherwise append only if the user has typed a valid address
+            values.forEach((value) => {
+              if (value && (isNameValid(value) || isAccountAddressValid(value))) {
+                parsedValues.push(value);
+              }
+            });
+          }
+          if (inputValue.value === ',') {
+            inputValue.value = '';
+          }
+          if (parsedValues.length > 0) {
+            inputValue.value = '';
+            emit('update:modelValue', [...parsedValues, ...props.modelValue].filter(removeDuplicates));
+          }
+        }
+      });
     });
 
     return {
+      messageAsObject,
+      hasError,
+      hasWarning,
       filteredOptions,
-      selectedAddress,
+      selectedAddresses,
       clearAddress,
+      clearAll,
       selectValue,
+      handleEnter,
+      inputValue,
       isDropdownOpen,
+      isNameValid,
+      isAccountAddressValid,
       CircleCloseIcon,
+      TrashIcon,
     };
   },
 });
@@ -181,16 +331,24 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @use '@/styles/variables' as *;
-@use '@/styles/typography';
 
 .input-field {
   .close-icon {
+    align-self: flex-end;
     padding: 0;
     opacity: 0.5;
   }
 
   .truncated-text {
     color: $color-white;
+  }
+
+  .error {
+    color: #{$color-danger};
+  }
+
+  .warning {
+    color: #{$color-warning};
   }
 
   .dropdown-wrapper {
@@ -226,6 +384,24 @@ export default defineComponent({
 
     .dropdown-item:not(:last-child) {
       border-bottom: 1px solid rgba($color-white, 0.15);
+    }
+  }
+
+  .selected-addresses-container {
+    flex-direction: column;
+    gap: 6px;
+    display: flex;
+    overflow: auto;
+    width: 100%;
+    max-height: 158px;
+    padding-top: 8px;
+    margin-top: 4px;
+    border-top: 1px solid rgba($color-white, 0.15);
+
+    .selected-address-container {
+      display: flex;
+      flex: 1;
+      gap: 4px;
     }
   }
 

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -306,6 +306,10 @@
           "title": "Send to .chain name",
           "linkTitle": "claim your own .chain name",
           "msg": "{0} AENS name is a human friendly nickname ending with .chain that points to recipient’s account. Before sending any funds make sure the recipient is still the name owner."
+        },
+        "multiple": {
+          "title": "Send to multiple recipients",
+          "msg": "{0} you can send the chosen amount of coins or tokens to multiple addresses and/or .chain names separated with commas or spaces."
         }
       }
     },
@@ -416,7 +420,7 @@
       "recipientLabel": "Recipient",
       "recipientPlaceholder": "Enter public address or .chain name",
       "recipientPlaceholderUrl": "Enter public address, .chain name or URL",
-      "recipientPlaceholderProtocol": "Enter {name} public address",
+      "recipientPlaceholderProtocol": "Enter {name} address",
       "recipientPlaceholderENS": "or ENS name",
       "transactionSpeed": "Transaction speed",
       "transactionWillBeCompleted": "Transaction will be completed in ≈{time}.",
@@ -693,6 +697,9 @@
       "scanTitle": "Scan the address you want to add",
       "selectRecipientAddress": "Select recipient’s address",
       "selectSignerAddress": "Select signer’s address",
+      "singleRecipient": "Single recipient",
+      "multipleRecipients": "Multiple recipients",
+      "useSelected": "Use selected",
       "noRecords": {
         "addressBook": "There are no records in your address book.",
         "blockchain": "Currently there are no address records for the blockchain selected.",
@@ -1085,17 +1092,23 @@
       "title": "Transaction has been submitted",
       "copy": "Copy QR code",
       "reviewtx": "Review transaction",
+      "multicheckalert": "to multiple recipients carefully",
       "checkalert": "Please check the information carefully.",
       "sender": "Sending address",
       "recipient": "Receiving address",
       "receivingUrl": "Receiving URL",
+      "show": "Show",
+      "hide": "Hide",
+      "recipients": "recipients",
       "sending": "Sending",
       "sentTo": "have been successfully sent to",
       "sendingCryptoToUrl": "Sending tip to URL",
       "tipInfo": "Your transaction will be publicly displayed as URL tip on {0}",
       "to": "To",
       "messageUrlOwner": "Message the URL owner (optional)",
-      "scanAddress": "Scan the recipient’s account address QR code in order to send {assetName} to them."
+      "scanAddress": "Scan the recipient’s account address QR code in order to send {assetName} to them.",
+      "singleAccountLabel": "Single transfer amount",
+      "multipleAccountLabel": "All transfers amount"
     },
     "signTransaction": {
       "reject": "Reject",
@@ -1359,6 +1372,7 @@
     "enoughCoin": "{0} balance is not enough to pay for transaction fee.",
     "enoughAeSigner": "Insufficient balance in your signing account to propose a transaction.",
     "maxLength": "Maximum {0} characters are allowed in this field.",
+    "maxRecipients": "Maximum {0} recipients are allowed in this field.",
     "maxValue": "Amount exceeds maximum available: {0}.",
     "maxRedeem": "Maximum redeemable amount is {0} AE.",
     "maxValueVault": "Amount exceeds vault balance: {0}.",

--- a/src/protocols/aeternity/components/TransferReviewTip.vue
+++ b/src/protocols/aeternity/components/TransferReviewTip.vue
@@ -51,7 +51,7 @@
     </span>
 
     <div class="tip-url">
-      {{ transferData.address }}
+      {{ transferData.addresses[0] }}
     </div>
 
     <FormTextarea

--- a/src/protocols/aeternity/components/TransferSendForm.vue
+++ b/src/protocols/aeternity/components/TransferSendForm.vue
@@ -60,9 +60,13 @@
 
     <template #recipient>
       <TransferSendRecipient
-        v-model="formModel.address"
+        v-model="formModel.addresses"
         :errors="errors"
         :is-tip-url="isTipUrl"
+        :is-url-tipping-enabled="isUrlTippingEnabled"
+        :max-recipients="isMultisig
+          || isActiveAccountAirGap
+          || isUrlTippingEnabled ? 1 : 10"
         :protocol="PROTOCOLS.aeternity"
         :placeholder="(isUrlTippingEnabled)
           ? $t('modals.send.recipientPlaceholderUrl')
@@ -71,7 +75,9 @@
           aens_name_registered_or_address_or_url: isUrlTippingEnabled,
           aens_name_registered_or_address: !isUrlTippingEnabled,
           ...(isMultisig
-            ? { address_not_same_as: [multisigVaultAddress, PROTOCOLS.aeternity] }
+            ? {
+              address_not_same_as: [multisigVaultAddress, PROTOCOLS.aeternity],
+            }
             : {}),
           token_to_an_address: [!isAe],
           airgap_to_an_address: isActiveAccountAirGap,
@@ -320,10 +326,10 @@ export default defineComponent({
     );
 
     const isTipUrl = computed(() => (
-      !!formModel.value.address
+      !!formModel.value.addresses
       && isUrlTippingEnabled.value
-      && isUrlValid(formModel.value.address)
-      && !isNameValid(formModel.value.address)
+      && isUrlValid(formModel.value.addresses[0])
+      && !isNameValid(formModel.value.addresses[0])
     ));
 
     const mySignerAccounts = accounts.value.filter(

--- a/src/protocols/aeternity/components/TransferSignedTxReview.vue
+++ b/src/protocols/aeternity/components/TransferSignedTxReview.vue
@@ -33,6 +33,7 @@
         <template #value>
           <AvatarWithChainName
             :address="senderId"
+            :protocol="PROTOCOLS.aeternity"
             show-address
           />
         </template>
@@ -46,6 +47,7 @@
         <template #value>
           <AvatarWithChainName
             :address="recipientId"
+            :protocol="PROTOCOLS.aeternity"
             show-address
           />
         </template>
@@ -202,11 +204,11 @@ export default defineComponent({
           amount: amountRaw,
           fee,
           selectedAsset,
-          address: recipient,
+          addresses: recipients,
         } = transferData.value!;
         const isSelectedAssetAeCoin = selectedAsset?.contractId === AE_CONTRACT_ID;
 
-        if (!amountRaw || !recipient || !selectedAsset) {
+        if (!amountRaw || !recipients?.length || !selectedAsset) {
           return;
         }
 
@@ -226,7 +228,7 @@ export default defineComponent({
             senderId: activeAccount.value.address,
             type: (isSelectedAssetAeCoin) ? Tag[Tag.SpendTx] : Tag[Tag.ContractCallTx],
             function: TX_FUNCTIONS.transfer,
-            recipientId: recipient,
+            recipientId: recipients[0],
             arguments: [],
             fee: Number(fee),
           },

--- a/src/protocols/aeternity/composables/aeNames.ts
+++ b/src/protocols/aeternity/composables/aeNames.ts
@@ -19,7 +19,7 @@ import {
   fetchJson,
   handleUnknownError,
 } from '@/utils';
-import { Encoded, Name } from '@aeternity/aepp-sdk';
+import { AensName, Encoded, Name } from '@aeternity/aepp-sdk';
 import {
   AUTO_EXTEND_NAME_BLOCKS_INTERVAL,
   PROTOCOLS,
@@ -74,6 +74,8 @@ const defaultNamesRegistry = useStorageRef<NamesRegistry>({}, STORAGE_KEYS.names
  */
 const externalNamesRegistry = ref<NamesRegistry>({});
 const auctions = ref<Record<string, IAuction>>({});
+
+const resolvedChainNames = ref<Record<Encoded.Name, AensName>>({});
 
 const initPollingWatcher = createPollingBasedOnMountedComponents(POLLING_INTERVAL);
 
@@ -137,9 +139,11 @@ export function useAeNames() {
     if (!address) {
       return '';
     }
-
-    const middleware = await getMiddleware();
-    return (await middleware.getName(address)).name;
+    if (!resolvedChainNames.value[address]) {
+      const middleware = await getMiddleware();
+      resolvedChainNames.value[address] = (await middleware.getName(address)).name;
+    }
+    return resolvedChainNames.value[address];
   }
 
   function getNameAuction(name: string): IAuction {
@@ -351,6 +355,7 @@ export function useAeNames() {
     ownedNames,
     areNamesFetching,
     updateOwnedNames,
+    resolvedChainNames,
     getName,
     getNameByNameHash,
     getNameAuction,

--- a/src/protocols/aeternity/libs/AeternityAdapter.ts
+++ b/src/protocols/aeternity/libs/AeternityAdapter.ts
@@ -531,7 +531,7 @@ export class AeternityAdapter extends BaseProtocolAdapter {
   override async spend(
     amount: number,
     recipient: string,
-    options: { payload: string },
+    options: { payload: string; nonce: number },
   ): Promise<ITransferResponse> {
     const { getAeSdk } = useAeSdk();
     const aeSdk = await getAeSdk();
@@ -541,6 +541,7 @@ export class AeternityAdapter extends BaseProtocolAdapter {
       {
         waitMined: false,
         payload: encode(Buffer.from(options.payload), Encoding.Bytearray),
+        nonce: options.nonce,
       },
     );
   }

--- a/src/protocols/aeternity/views/TransferSendModal.vue
+++ b/src/protocols/aeternity/views/TransferSendModal.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     const currentStep = ref<TransferSendStep>(TRANSFER_SEND_STEPS.form);
     const error = ref(false);
     const transferData = ref<TransferFormModel>({
-      address: props.address as any, // TODO change to string globally
+      addresses: props.address ? [props.address] : [] as any[], // TODO change to string globally
       amount: props.amount,
       payload: props.payload,
       selectedAsset: (props.tokenContractId)
@@ -83,12 +83,13 @@ export default defineComponent({
         : undefined,
     });
 
-    const isAddressChain = computed(() => !!transferData.value.address?.endsWith(AE_AENS_DOMAIN));
+    const isAddressChain = computed(() => (
+      !!transferData.value.addresses?.[0]?.endsWith(AE_AENS_DOMAIN)));
 
     const isAddressUrl = computed(() => (
       !isAddressChain.value
-      && transferData.value.address
-      && isUrlValid(transferData.value.address)
+      && transferData.value.addresses
+      && isUrlValid(transferData.value.addresses[0])
     ));
 
     const showNextButton = computed(() => (
@@ -99,7 +100,10 @@ export default defineComponent({
     const isSendingDisabled = computed(() => (
       error.value
       || !isAeNodeReady.value
-      || (!showNextButton.value && (!transferData.value.address || !transferData.value.amount))
+      || (
+        !showNextButton.value
+        && (!transferData.value.addresses?.length || !transferData.value.amount)
+      )
     ));
 
     const customPrimaryButtonText = computed(() => {

--- a/src/protocols/bitcoin/views/TransferSendModal.vue
+++ b/src/protocols/bitcoin/views/TransferSendModal.vue
@@ -2,7 +2,9 @@
   <TransferSendBase
     :protocol="PROTOCOLS.bitcoin"
     :current-step="currentStep"
-    :sending-disabled="error || !transferData.address || !transferData.amount"
+    :sending-disabled="error
+      || !transferData.addresses?.length
+      || !transferData.amount"
     @close="resolve"
     @step-next="proceedToNextStep"
     @step-prev="editTransfer"
@@ -60,7 +62,7 @@ export default defineComponent({
     const currentStep = ref<TransferSendStep>(TRANSFER_SEND_STEPS.form);
     const error = ref(false);
     const transferData = ref<TransferFormModel>({
-      address: props.address as any, // TODO change to string globally
+      addresses: props.address ? [props.address] : [] as any[], // TODO change to string globally
       amount: props.amount,
       payload: props.payload,
       selectedAsset: ProtocolAdapterFactory

--- a/src/protocols/ethereum/components/TransferSendForm.vue
+++ b/src/protocols/ethereum/components/TransferSendForm.vue
@@ -11,7 +11,8 @@
   >
     <template #recipient>
       <TransferSendRecipient
-        v-model.trim="formModel.address"
+        v-model="formModel.addresses"
+        :max-recipients="10"
         :placeholder="recipientPlaceholderText"
         :errors="errors"
         :protocol="PROTOCOLS.ethereum"
@@ -133,17 +134,7 @@ export default defineComponent({
     const { marketData } = useCurrencies();
     const { balance } = useBalances();
     const { activeAccount } = useAccounts();
-    const {
-      fee,
-      maxFee,
-      feeList,
-      feeSelectedIndex,
-      maxFeePerGas,
-      maxPriorityFeePerGas,
-      updateFeeList,
-    } = useEthFeeCalculation();
     const { accountAssets } = useAccountAssetsList();
-    const { ethActiveNetworkSettings } = useEthNetworkSettings();
 
     function getSelectedAssetValue(assetContractId?: AssetContractId, selectedAsset?: IAsset) {
       if (assetContractId) {
@@ -155,7 +146,6 @@ export default defineComponent({
       }
       return undefined;
     }
-
     const {
       formModel,
       errors,
@@ -169,6 +159,17 @@ export default defineComponent({
       transferData: props.transferData,
       getSelectedAssetValue,
     });
+    const recipientsCount = computed(() => formModel.value.addresses?.length || 1);
+    const {
+      fee,
+      maxFee,
+      feeList,
+      feeSelectedIndex,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      updateFeeList,
+    } = useEthFeeCalculation(recipientsCount);
+    const { ethActiveNetworkSettings } = useEthNetworkSettings();
 
     const shouldUseMaxAmount = ref(false);
 
@@ -185,7 +186,7 @@ export default defineComponent({
         fee: fee.value as BigNumber,
         maxFeePerGas: maxFeePerGas.value?.toFormat(ETH_COIN_PRECISION),
         maxPriorityFeePerGas: maxPriorityFeePerGas.value?.toFormat(ETH_COIN_PRECISION),
-        total: numericFee.value + +(formModel.value?.amount || 0),
+        total: numericFee.value + +(formModel.value?.amount || 0) * recipientsCount.value,
         invoiceId: invoiceId.value,
         invoiceContract: invoiceContract.value,
       };
@@ -208,22 +209,27 @@ export default defineComponent({
       }
     }
 
-    function getTransferGasLimit() {
+    async function getTransferGasLimit() {
       const amount = new BigNumber(formModel.value.amount!);
       if (
         props.transferData.selectedAsset?.contractId !== 'ethereum'
         && amount.gt(0)
-        && formModel.value.address
+        && formModel.value.addresses?.length
       ) {
         const { nodeUrl } = ethActiveNetworkSettings.value;
 
-        return getTokenTransferGasLimit(
-          formModel.value.selectedAsset?.contractId!,
-          formModel.value.address,
-          activeAccount.value?.address,
-          amount,
-          nodeUrl,
+        const results = await Promise.all(
+          formModel.value.addresses.map((address) => getTokenTransferGasLimit(
+            formModel.value.selectedAsset?.contractId!,
+            address,
+            activeAccount.value?.address,
+            amount,
+            nodeUrl,
+          )),
         );
+
+        const total = results.reduce((sum, value) => sum + value, 0);
+        return total;
       }
       return undefined;
     }
@@ -294,6 +300,7 @@ export default defineComponent({
       errors,
       balance,
       max,
+      recipientsCount,
       shouldUseMaxAmount,
       scanTransferQrCode,
       handleAssetChange,

--- a/src/protocols/ethereum/components/TransferSendForm.vue
+++ b/src/protocols/ethereum/components/TransferSendForm.vue
@@ -87,6 +87,7 @@ import {
 } from '@/composables';
 import { useEthFeeCalculation } from '@/protocols/ethereum/composables/ethFeeCalculation';
 import { useTransferSendForm } from '@/composables/transferSendForm';
+import { useCoinMaxAmount } from '@/composables/coinMaxAmount';
 import { NETWORK_TYPE_TESTNET, PROTOCOLS } from '@/constants';
 import { executeAndSetInterval } from '@/utils';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
@@ -95,7 +96,6 @@ import {
   ETH_COIN_SYMBOL,
   ETH_PROTOCOL_NAME,
 } from '@/protocols/ethereum/config';
-import { useEthMaxAmount } from '@/protocols/ethereum/composables/ethMaxAmount';
 import { useEthNetworkSettings } from '@/protocols/ethereum/composables/ethNetworkSettings';
 import { getTokenTransferGasLimit } from '@/protocols/ethereum/helpers';
 
@@ -173,7 +173,7 @@ export default defineComponent({
 
     const shouldUseMaxAmount = ref(false);
 
-    const { max } = useEthMaxAmount({ formModel, fee: maxFee });
+    const { max } = useCoinMaxAmount({ formModel, fee: maxFee });
 
     const numericFee = computed(() => +fee.value.toFixed());
     const numericMaxFee = computed(() => +maxFee.value.toFixed());

--- a/src/protocols/ethereum/components/TransferSendForm.vue
+++ b/src/protocols/ethereum/components/TransferSendForm.vue
@@ -178,7 +178,7 @@ export default defineComponent({
     const numericFee = computed(() => +fee.value.toFixed());
     const numericMaxFee = computed(() => +maxFee.value.toFixed());
 
-    const recipientPlaceholderText = `${t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOLS.ethereum })} ${t('modals.send.recipientPlaceholderENS')}`;
+    const recipientPlaceholderText = `${t('modals.send.recipientPlaceholderProtocol', { name: PROTOCOLS.ethereum })}`;
 
     function emitCurrentFormModelState() {
       const inputPayload: TransferFormModel = {

--- a/src/protocols/ethereum/composables/ethFeeCalculation.ts
+++ b/src/protocols/ethereum/composables/ethFeeCalculation.ts
@@ -1,7 +1,12 @@
 import { Web3Eth } from 'web3-eth';
 import { fromWei } from 'web3-utils';
 import BigNumber from 'bignumber.js';
-import { computed, ref } from 'vue';
+import {
+  computed,
+  ComputedRef,
+  Ref,
+  ref,
+} from 'vue';
 
 import type { IFeeItem } from '@/types';
 import { tg } from '@/popup/plugins/i18n';
@@ -14,7 +19,7 @@ const MAX_PRIORITY_FEE_MULTIPLIERS = {
   fast: 2,
 } as const;
 
-export function useEthFeeCalculation() {
+export function useEthFeeCalculation(recipientsCount: Ref<number> | ComputedRef<number> = ref(1)) {
   const { ethActiveNetworkSettings } = useEthNetworkSettings();
 
   const feeSelectedIndex = ref(0);
@@ -70,12 +75,17 @@ export function useEthFeeCalculation() {
     },
   ]);
 
-  const fee = computed(() => feeList.value[feeSelectedIndex.value].fee);
-  const maxFeePerGas = computed(() => feeList.value[feeSelectedIndex.value].maxFeePerGas);
+  const fee = computed(() => (
+    feeList.value[feeSelectedIndex.value].fee.multipliedBy(recipientsCount.value)
+  ));
+  const maxFeePerGas = computed(() => (
+    feeList.value[feeSelectedIndex.value].maxFeePerGas!.multipliedBy(recipientsCount.value)
+  ));
   const maxPriorityFeePerGas = computed(
-    () => feeList.value[feeSelectedIndex.value].maxPriorityFee,
+    () => feeList.value[feeSelectedIndex.value].maxPriorityFee!.multipliedBy(recipientsCount.value),
   );
-  const maxFee = computed(() => maxFeePerGas.value!.multipliedBy(gasLimit.value));
+  const maxFee = computed(() => (
+    maxFeePerGas.value!.multipliedBy(gasLimit.value).multipliedBy(recipientsCount.value)));
 
   async function updateFeeList(newGasLimit?: number) {
     gasLimit.value = newGasLimit ?? ETH_GAS_LIMIT;

--- a/src/protocols/ethereum/libs/EthereumAdapter.ts
+++ b/src/protocols/ethereum/libs/EthereumAdapter.ts
@@ -362,6 +362,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
       fromAccount: AccountAddress;
       maxPriorityFeePerGas: string;
       maxFeePerGas: string;
+      nonce: number;
     },
   ): Promise<ITransferResponse> {
     const {
@@ -399,7 +400,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
     const maxPriorityFeePerGas = bigIntToHex(BigInt(toWei(options.maxPriorityFeePerGas, 'ether')));
     const maxFeePerGas = bigIntToHex(BigInt(toWei(options.maxFeePerGas, 'ether')));
 
-    const [nonce, gasLimit] = await Promise.all([
+    const [gasLimit] = await Promise.all([
       this.getTransactionCount(options.fromAccount),
       contract.methods.transfer(recipient, hexAmount).estimateGas(),
     ]);
@@ -407,7 +408,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
     // All values are in wei
     const txData: FeeMarketEIP1559TxData = {
       chainId: toHex(chainId),
-      nonce,
+      nonce: options.nonce,
       to: contractId,
       data: contract.methods.transfer(recipient, hexAmount).encodeABI(),
       value: 0x0,
@@ -540,7 +541,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
       throw new Error('Ethereum transaction construction & signing was initiated from non existing or not ethereum account.');
     }
 
-    const nonce = await this.getTransactionCount(options.fromAccount);
+    const { nonce } = options;
     const { chainId } = ethActiveNetworkSettings.value;
 
     const hexAmount = bigIntToHex(BigInt(toWei(amount.toFixed(ETH_COIN_PRECISION), 'ether')));
@@ -570,6 +571,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
       fromAccount: AccountAddress;
       maxPriorityFeePerGas: string;
       maxFeePerGas: string;
+      nonce: number;
     },
   ): Promise<ITransferResponse> {
     const web3Eth = this.getWeb3EthInstance();

--- a/src/protocols/ethereum/views/TransferSendModal.vue
+++ b/src/protocols/ethereum/views/TransferSendModal.vue
@@ -1,7 +1,9 @@
 <template>
   <TransferSendBase
     :current-step="currentStep"
-    :sending-disabled="error || !transferData.address || !transferData.amount"
+    :sending-disabled="error
+      || !transferData.addresses?.length
+      || !transferData.amount"
     @close="resolve"
     @step-next="proceedToNextStep"
     @step-prev="editTransfer"
@@ -62,7 +64,7 @@ export default defineComponent({
     const currentStep = ref<TransferSendStep>(TRANSFER_SEND_STEPS.form);
     const error = ref(false);
     const transferData = ref<TransferFormModel>({
-      address: props.address as any, // TODO change to string globally
+      addresses: props.address ? [props.address] : [] as any[], // TODO change to string globally
       amount: props.amount,
       payload: props.payload,
       selectedAsset: (props.tokenContractId)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -818,7 +818,7 @@ export type StatusIconType = typeof ALLOWED_ICON_STATUSES[number];
 export interface IFormModel {
   amount?: string;
   selectedAsset?: IAsset;
-  address?: Encoded.AccountAddress;
+  addresses?: Encoded.AccountAddress[];
   payload?: string;
 }
 
@@ -848,6 +848,7 @@ export interface ITransferArgs {
   amount: string | BigNumberPublic;
   recipient: AccountAddress;
   selectedAsset: IAsset;
+  nonce?: number;
 }
 
 export type MarketData = Record<Protocol, CoinGeckoMarketResponse>;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -169,6 +169,10 @@ export function excludeFalsy<T>(value: T): value is Truthy<T> {
   return !!value;
 }
 
+export function removeDuplicates<T>(entry: T, index: number, self: T[]): boolean {
+  return self.findIndex((e) => e !== undefined && e === entry) === index;
+}
+
 export function executeAndSetInterval(handler: () => any, timeout: number) {
   handler();
   return setInterval(handler, timeout);

--- a/src/utils/transferSend.ts
+++ b/src/utils/transferSend.ts
@@ -4,6 +4,9 @@ import { tg } from '@/popup/plugins/i18n';
 // TODO: in the future we might rely on the error codes instead
 // "//" symbol is a chosen splitter
 const splitter = '//';
+// Some new validations also return further information on the error
+// message that have to be ignored. These come after the "||"
+const arraySplitter = '||';
 const WARNING_RULES_WORDING = [
   tg('validation.addressNotSameAs', [splitter]),
   tg('validation.maxValueVault', [splitter]),
@@ -14,8 +17,10 @@ export function getMessageByFieldName(errorField?: string): IInputMessage {
     return { status: 'success' };
   }
   if (WARNING_RULES_WORDING.some((rule) => {
-    const splittedRule = rule.split(splitter);
-    return errorField.startsWith(splittedRule[0]) && errorField.endsWith(splittedRule[1]);
+    const splittedRule = rule.split(arraySplitter)[0].split(splitter);
+    const splittedErrorField = errorField?.split(arraySplitter)[0];
+    return splittedErrorField.startsWith(splittedRule[0])
+    && splittedErrorField.endsWith(splittedRule[1]);
   })) {
     return { status: 'warning', text: errorField };
   }

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -331,17 +331,31 @@ Cypress.Commands.add('generateReceiveLinkAndVisit', (address, amount, token = nu
     .invoke('readText')
     .then(async (text) => {
       const receiveUrl = await text;
-      cy.login({}, receiveUrl.replace(APP_LINK_WEB, ''))
-        .get('[data-cy=address] [data-cy=textarea]')
-        .should('have.value', address)
-        .get('[data-cy=amount] [data-cy=input]')
-        .should('have.value', amount);
+      cy.login({}, receiveUrl.replace(APP_LINK_WEB, ''));
 
-      if (token) {
-        cy.get('[data-cy=select-asset]')
-          .should('contain', token.name);
-      }
-      cy.get('[data-cy=btn-close]')
-        .click();
+      cy.get('[data-cy="input-wrapper"] .truncate');
+
+      cy.document().then(($document) => {
+        // When a valid address (based on selected coin) is entered, the format changes
+        const documentResult = $document.querySelectorAll('[data-cy=input-wrapper] .under .address-truncated .address-chunk:first-child');
+        if (documentResult.length) {
+          cy.get('[data-cy=input-wrapper] .under .address-truncated .address-chunk:first-child')
+            .should('have.text', address.substr(0, 6));
+          cy.get('[data-cy=input-wrapper] .under .address-truncated .address-chunk:last-child')
+            .should('have.text', address.substr(-3));
+        } else {
+          // Invalid address
+          cy.get('[data-cy=input-wrapper] .truncate')
+            .should('have.text', address);
+        }
+        cy.get('[data-cy=amount] [data-cy=input]')
+          .should('have.value', amount);
+        if (token) {
+          cy.get('[data-cy=select-asset]')
+            .should('contain', token.name);
+        }
+        cy.get('[data-cy=btn-close]')
+          .click();
+      });
     });
 });

--- a/tests/unit/composables/open-scan-qr-modal.spec.js
+++ b/tests/unit/composables/open-scan-qr-modal.spec.js
@@ -63,20 +63,20 @@ describe('scanTransferQrCode', () => {
 
   it('parses address qr code', async () => {
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_ACCOUNT.addressAeternity);
+    expect(formModel.value.addresses[0]).toBe(STUB_ACCOUNT.addressAeternity);
   });
 
   it('parses ae amount qr code', async () => {
     numberOfTheTest = 1;
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_ACCOUNT.addressAeternity);
+    expect(formModel.value.addresses[0]).toBe(STUB_ACCOUNT.addressAeternity);
     expect(formModel.value.amount).toBe(testAmount);
   });
 
   it('parses contract amount qr code', async () => {
     numberOfTheTest = 2;
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_ACCOUNT.addressAeternity);
+    expect(formModel.value.addresses[0]).toBe(STUB_ACCOUNT.addressAeternity);
     expect(formModel.value.amount).toBe(testAmount);
     expect(formModel.value.selectedAsset).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
   });
@@ -84,7 +84,7 @@ describe('scanTransferQrCode', () => {
   it('parses contract amount legacy qr code', async () => {
     numberOfTheTest = 3;
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_ACCOUNT.addressAeternity);
+    expect(formModel.value.addresses[0]).toBe(STUB_ACCOUNT.addressAeternity);
     expect(formModel.value.amount).toBe(testAmount);
     expect(formModel.value.selectedAsset).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
   });
@@ -92,7 +92,7 @@ describe('scanTransferQrCode', () => {
   it('parses zeit contract qr code', async () => {
     numberOfTheTest = 4;
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
+    expect(formModel.value.addresses[0]).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
     expect(formModel.value.amount).toBe(testAmount);
     expect(formModel.value.selectedAsset.contractId).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
     expect(invoiceId.value).toBe(testInvoiceId);
@@ -102,7 +102,7 @@ describe('scanTransferQrCode', () => {
   it('handles user scan reject with existing data', async () => {
     numberOfTheTest = 5;
     await scanTransferQrCode();
-    expect(formModel.value.address).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
+    expect(formModel.value.addresses[0]).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
     expect(formModel.value.amount).toBe(testAmount);
     expect(formModel.value.selectedAsset.contractId).toBe(STUB_TOKEN_CONTRACT_ADDRESS);
   });


### PR DESCRIPTION
closes #3365 

- Recipients is now an array of string, instead of a single string
- Validation occurs on each address of the array individually
- Up to 10 addresses can be entered
- On AirGap & Multisig only 1 address can be entered
- When tipping URL is enabled, only 1 address can be entered, with the limitation of showing the address as a string (instead of the nicer format). Since we cannot know when the user has entered a valid URL, I cannot automatically enter it to the list. For this reason, only for this case, the nicer format of the list is hidden
- Modified ETH placeholder since ENS is not yet supported